### PR TITLE
Ticket/62550

### DIFF
--- a/titania/includes/objects/category.php
+++ b/titania/includes/objects/category.php
@@ -473,7 +473,7 @@ class titania_category extends titania_message_object
 			$url .= $row['category_name_clean'] . '/';
 		}
 
-		return titania_url::build_url($url) . $this->category_name_clean . '-' . $this->category_id;
+		return titania_url::build_url($url . $this->category_name_clean . '-' . $this->category_id);
 	}
 
 	/**


### PR DESCRIPTION
[ticket/62550] Correctly build category-url

Currently the "categoryname-id"-component is added to the end of the url. But
this conflicts with the behavior of the sid, which leads to a new sessions. So
you get logged out with cookies disabled. The fix is quite easy. The
"categoryname-id"-component needs to be part of the url or url_building
function and not be appended afterwards.
