### PR TITLE
Fix for ticket 62979

### DIFF
--- a/titania/includes/types/style.php
+++ b/titania/includes/types/style.php
@@ -141,7 +141,6 @@ class titania_type_style extends titania_type_base
 				'u_titania_mod_style_queue',
 				'u_titania_mod_style_validate',
 				'u_titania_mod_style_moderate',
-				'u_titania_mod_style_clr',
 			));
 
 			// Style count holder


### PR DESCRIPTION
Permission u_titania_mod_style_clr already being added in function auto_install() in includes/versions.php, entry in includes/types/styles.php is a duplicate that causes installation to fail.
