### PR TITLE
Convert single quote entities back to character. Bug #62850.

### DIFF
--- a/titania/includes/functions.php
+++ b/titania/includes/functions.php
@@ -77,7 +77,7 @@ function titania_decode_message(&$message, $bbcode_uid = '')
 	$message = str_replace('&nbsp;', ' ', $message);
 
 	// Decode HTML entities, else bbcode reparsing will fail
-	$message = html_entity_decode($message);
+	$message = html_entity_decode($message, ENT_QUOTES);
 
 	// With magic_quotes_gpc on slashes are stripped too many times, so add them
 	$message = (STRIP) ? addslashes($message) : $message;


### PR DESCRIPTION
titania_decode_message() converts entities back to their characters before sending the message off to set_var(), which then runs htmlspecialchars(). Since html_entity_decode() ignores single quotes by default, the ampersand in the single quote entity is converted to an entity in set_var. Adding the ENT_QUOTES option to html_entity_decode() fixes this.
