### PR TITLE
Fix excessive query execution in the contribution lists

### DIFF
--- a/titania/includes/objects/contribution.php
+++ b/titania/includes/objects/contribution.php
@@ -462,7 +462,7 @@ class titania_contribution extends titania_message_object
 		// Display real author
 		if ($return)
 		{
-			$vars = array_merge($vars, $this->author->assign_details(true));
+			$vars['AUTHOR_NAME_FULL'] = $this->author->get_username_string();
 		}
 		else
 		{


### PR DESCRIPTION
The author's complete profile info was being requested when the only info needed was the full username string for every contribution. This cuts ~190 queries from the "All Contributions" page.
