### PR TITLE
Fix issue with certain image attachments not displaying in IE when viewed in a page. Bug #62902.

### DIFF
--- a/titania/includes/tools/attachment.php
+++ b/titania/includes/tools/attachment.php
@@ -779,11 +779,11 @@ class titania_attachment extends titania_database_object
 				case ATTACHMENT_CATEGORY_IMAGE:
 					$l_downloaded_viewed = 'VIEWED_COUNT';
 
-					$download_link = titania_url::append_url($download_link, array('mode' => 'view'));
+					$download_link = ($attachment['thumbnail']) ? titania_url::append_url($download_link, array('mode' => 'view')) : $download_link;
 
 					$block_array += array(
 						'S_IMAGE'			=> true,
-						'U_INLINE_LINK'		=> titania_url::append_url($download_link, array('mode' => 'view')),
+						'U_INLINE_LINK'		=> $download_link,
 					);
 				break;
 
@@ -1154,11 +1154,11 @@ class titania_attachment extends titania_database_object
 				case ATTACHMENT_CATEGORY_IMAGE:
 					$l_downloaded_viewed = 'VIEWED_COUNT';
 
-					$download_link = titania_url::append_url($download_link, array('mode' => 'view'));
+					$download_link = ($attachment['thumbnail']) ? titania_url::append_url($download_link, array('mode' => 'view')) : $download_link;
 
 					$block_array += array(
 						'S_IMAGE'			=> true,
-						'U_INLINE_LINK'		=> titania_url::append_url($download_link, array('mode' => 'view')),
+						'U_INLINE_LINK'		=> $download_link,
 					);
 				break;
 

--- a/titania/js/common.js
+++ b/titania/js/common.js
@@ -171,6 +171,10 @@ $(document).ready(function(){
 		createCookie('cdb_ignore_subscription', 'true', 365);
 		$.colorbox.close();
 	});
+  
+	// Remove -mode_view from screenshot links as we'll be displaying the image inline, so file.php should not
+	// wrap the image in html in IE
+	$.each($('a.screenshot'), function() {this.href = this.href.replace('-mode_view', '');});
 });
 
 function hide_quotebox(box)


### PR DESCRIPTION
- mode_view should only be added to images that are to be accessed directly, otherwise the image gets wrapped in HTML and thus becomes invalid when trying to use in &lt;img&gt; tag. This addresses not only screenshots, but images in posts as well.
- We remove the parameter for the larger version of screenshots (displayed using ColorBox) using JS in order to avoid causing problems for users that have JS disabled.
