### PR TITLE
Fix typo in .com's official_tools.php

### DIFF
--- a/titania/includes/types/official_tools.php
+++ b/titania/includes/types/official_tools.php
@@ -36,7 +36,7 @@ class titania_type_official_tools extends titania_type_base
 	 *
 	 * @var string (any lang key that includes the type should match this value)
 	 */
-	public $name = 'offical_tool';
+	public $name = 'official_tool';
 
 	/**
 	 * For the url slug


### PR DESCRIPTION
The type name for official tools is spelled wrong.
