### PR TITLE
Screenshots wrapped in <a> tag do not appear in IE8. Bug #63075. 

### DIFF
--- a/titania/styles/prosilver/theme/common.css
+++ b/titania/styles/prosilver/theme/common.css
@@ -287,7 +287,7 @@ ul.general-info li strong {
 #screenshots-panel a.screenshot img, img.screenshot  {
 	padding: 3px;
 	border: 1px solid #A1A1A1;
-	vertical-align: top;
+	vertical-align: text-top;
 	margin: 5px;
 }
 


### PR DESCRIPTION
- IE8: die.
- This is already fixed in the default style.
