### PR TITLE
Marking topics read in support section is ignored. Bug #63004

### DIFF
--- a/titania/common.php
+++ b/titania/common.php
@@ -22,7 +22,7 @@ if (!defined('NOT_IN_COMMUNITY'))
 }
 
 // Version number (only used for the installer)
-define('TITANIA_VERSION', '0.3.17');
+define('TITANIA_VERSION', '0.4.0');
 
 define('PHPBB_USE_BOARD_URL_PATH', true);
 if (!defined('IN_TITANIA_INSTALL'))

--- a/titania/includes/constants.php
+++ b/titania/includes/constants.php
@@ -63,6 +63,7 @@ define('TITANIA_SCREENSHOT', 11);
 define('TITANIA_ATTENTION', 12);
 define('TITANIA_TRANSLATION', 13);
 define('TITANIA_CLR_SCREENSHOT', 14); // ColorizeIt sample image
+define('TITANIA_ALL_SUPPORT', 15);
 
 // Errorbox types
 define('TITANIA_ERROR', 1);

--- a/titania/includes/functions_install.php
+++ b/titania/includes/functions_install.php
@@ -179,17 +179,17 @@ function titania_custom($action, $version)
 				case '0.3.16' :
 				case '0.3.17' :
 					$sql = 'SELECT DISTINCT topic_id, post_user_id
-						FROM ' . TITANIA_POSTS_TABLE . ' 
+						FROM ' . TITANIA_POSTS_TABLE . '
 						WHERE post_approved = 1 AND post_deleted = 0';
 					$result = phpbb::$db->sql_query($sql);
-					
+
 					$data = array();
 					$i = 0;
 
 					while ($row = phpbb::$db->sql_fetchrow($result))
 					{
 						$batch = floor($i / 500);
-						
+
 						$data[$batch][] = array(
 							'topic_id'		=> (int) $row['topic_id'],
 							'user_id'		=> (int) $row['post_user_id'],
@@ -207,9 +207,17 @@ function titania_custom($action, $version)
 						{
 							phpbb::$db->sql_multi_insert(TITANIA_TOPICS_POSTED_TABLE, $rows);
 						}
-						
+
 						unset($data);
-					}				
+					}
+				break;
+
+				case '0.4.0' :
+					$sql = 'UPDATE ' . TITANIA_TRACK_TABLE . '
+						SET track_type = ' . TITANIA_ALL_SUPPORT . '
+						WHERE track_type = ' . TITANIA_SUPPORT . '
+							AND track_id = 0';
+					phpbb::$db->sql_query($sql);
 				break;
 			}
 		break;

--- a/titania/includes/overlords/topics.php
+++ b/titania/includes/overlords/topics.php
@@ -308,8 +308,8 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 				$topic->additional_unread_fields[] = array('type' => TITANIA_SUPPORT, 'parent_match' => true);
 
 				// Additional tracking for all support topics
-				titania_tracking::get_track_sql($sql_ary, TITANIA_SUPPORT, 0, 'tstg');
-				$topic->additional_unread_fields[] = array('type' => TITANIA_SUPPORT, 'id' => 0, 'type_match' => true);
+				titania_tracking::get_track_sql($sql_ary, TITANIA_ALL_SUPPORT, 0, 'tstg');
+				$topic->additional_unread_fields[] = array('type' => TITANIA_ALL_SUPPORT, 'id' => 0);
 
 				// Track the queue discussion too if applicable
 				if (titania_types::find_authed('queue_discussion'))
@@ -364,9 +364,12 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 				// Additional tracking field (to allow marking all support/discussion as read)
 				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . TITANIA_SUPPORT;
 
+				titania_tracking::get_track_sql($sql_ary, TITANIA_SUPPORT, 'contrib.contrib_id', 'tst');
+				$topic->additional_unread_fields[] = array('type' => TITANIA_SUPPORT, 'parent_match' => true);
+
 				// Additional tracking for all support topics
-				titania_tracking::get_track_sql($sql_ary, TITANIA_SUPPORT, 0, 'tstg');
-				$topic->additional_unread_fields[] = array('type' => TITANIA_SUPPORT, 'id' => 0);
+				titania_tracking::get_track_sql($sql_ary, TITANIA_ALL_SUPPORT, 0, 'tstg');
+				$topic->additional_unread_fields[] = array('type' => TITANIA_ALL_SUPPORT, 'id' => 0);
 
 				// Do not order stickies first
 				$sql_ary['ORDER_BY'] = $sort->get_order_by();
@@ -393,8 +396,8 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 				$topic->additional_unread_fields[] = array('type' => TITANIA_SUPPORT, 'parent_match' => true);
 
 				// Additional tracking for all support topics
-				titania_tracking::get_track_sql($sql_ary, TITANIA_SUPPORT, 0, 'tstg');
-				$topic->additional_unread_fields[] = array('type' => TITANIA_SUPPORT, 'id' => 0);
+				titania_tracking::get_track_sql($sql_ary, TITANIA_ALL_SUPPORT, 0, 'tstg');
+				$topic->additional_unread_fields[] = array('type' => TITANIA_ALL_SUPPORT, 'id' => 0);
 
 				// Track the queue discussion too if applicable
 				if (titania_types::$types[$object->contrib_type]->acl_get('queue_discussion'))

--- a/titania/includes/tools/tracking.php
+++ b/titania/includes/tools/tracking.php
@@ -221,7 +221,7 @@ class titania_tracking
 		{
 			if (strpos($name, 'track_time_') === 0 && strpos($name, '_id') === false)
 			{
-				$type = (int) substr($name, 11, 1);
+				$type = (int) substr($name, 11, 2);
 
 				if (!isset($row['track_time_' . $type . '_id']))
 				{

--- a/titania/includes/versions.php
+++ b/titania/includes/versions.php
@@ -633,7 +633,7 @@ $versions = array(
 	'0.3.9' => array(
 		'custom' => 'titania_custom',
 	),
-	
+
 	'0.3.10' => array(
 		'table_column_add' => array(
 			array(TITANIA_ATTACHMENTS_TABLE, 'is_preview', array('TINT:1', 0)),
@@ -695,6 +695,9 @@ $versions = array(
 				),
 			)),
 		'custom'		=> 'titania_custom',
+	),
+	'0.4.0' => array(
+		'custom'	=> 'titania_custom',
 	),
 	// IF YOU ADD A NEW VERSION DO NOT FORGET TO INCREMENT THE VERSION NUMBER IN common.php!
 );

--- a/titania/index.php
+++ b/titania/index.php
@@ -210,7 +210,7 @@ switch ($action)
 			// Mark all topics read
 			if (request_var('mark', '') == 'topics')
 			{
-				titania_tracking::track(TITANIA_SUPPORT, 0);
+				titania_tracking::track(TITANIA_ALL_SUPPORT, 0);
 			}
 
 			// Mark all topics read


### PR DESCRIPTION
http://www.phpbb.com/bugs/titania/63004

Marking topics read in the support/discussion section now takes effect in both the support/discussion section as well as the "All support topics" section.
