### PR TITLE
Retesting MPV or AutoMOD should create a new post with results. Bug #62388.

### DIFF
--- a/titania/includes/objects/revision.php
+++ b/titania/includes/objects/revision.php
@@ -446,17 +446,15 @@ class titania_revision extends titania_database_object
 		$repack_message = phpbb::$user->lang['REVISION_REPACKED'] . "\n\n";
 
 		// Add the MPV results
-		if ($old_queue->mpv_results)
+		if ($queue->mpv_results)
 		{
-			$mpv_results = $old_queue->mpv_results;
-			titania_decode_message($mpv_results, $old_queue->mpv_results_uid);
-			$repack_message .= '[quote=&quot;' . phpbb::$user->lang['OLD_VALIDATION_MPV'] . '&quot;]' . $mpv_results . "[/quote]\n";
+			$repack_message .= '[quote=&quot;' . phpbb::$user->lang['VALIDATION_MPV'] . '&quot;]' . $queue->mpv_results . "[/quote]\n";
 		}
 
 		// Add the Automod results
-		if ($old_queue->automod_results)
+		if ($queue->automod_results)
 		{
-			$repack_message .= '[quote=&quot;' . phpbb::$user->lang['OLD_VALIDATION_AUTOMOD'] . '&quot;]' . $old_queue->automod_results . "[/quote]\n";
+			$repack_message .= '[quote=&quot;' . phpbb::$user->lang['VALIDATION_AUTOMOD'] . '&quot;]' . $queue->automod_results . "[/quote]\n";
 		}
 
 		// Reply
@@ -464,10 +462,6 @@ class titania_revision extends titania_database_object
 
 		// Update the old queue with the new results
 		$old_queue->revision_id = $queue->revision_id;
-		$old_queue->mpv_results = $queue->mpv_results;
-		$old_queue->mpv_results_bitfield = $queue->mpv_results_bitfield;
-		$old_queue->mpv_results_uid = $queue->mpv_results_uid;
-		$old_queue->automod_results = $queue->automod_results;
 		$old_queue->submit();
 
 		// Delete the new queue we made for this revision

--- a/titania/index.php
+++ b/titania/index.php
@@ -89,7 +89,7 @@ switch ($action)
 	case 'mpv' :
 	case 'automod' :
 		$revision_id = request_var('revision', 0);
-		titania::add_lang('contributions');
+		titania::add_lang(array('contributions', 'manage'));
 
 		// Get the revision, contribution, attachment, and queue
 		$revision = new titania_revision(false, $revision_id);
@@ -133,14 +133,8 @@ switch ($action)
 			}
 			else
 			{
-				$uid = $bitfield = $flags = false;
-				generate_text_for_storage($mpv_results, $uid, $bitfield, $flags, true, true, true);
-
-				// Add the MPV Results to the queue
-				$queue->mpv_results = $mpv_results;
-				$queue->mpv_results_bitfield = $bitfield;
-				$queue->mpv_results_uid = $uid;
-				$queue->submit();
+				$mpv_results = phpbb::$user->lang['VALIDATION_MPV'] . "\n[quote=&quot;" . phpbb::$user->lang['VALIDATION_MPV'] . '&quot;]' . $mpv_results . "[/quote]\n";
+				$queue->topic_reply($mpv_results);
 			}
 		}
 		else if ($action == 'automod')
@@ -178,12 +172,11 @@ switch ($action)
 			}
 			phpbb::$db->sql_freeresult($result);
 
-			$bbcode_results = implode("\n\n", $bbcode_results);
+			$bbcode_results = phpbb::$user->lang['VALIDATION_AUTOMOD'] . "\n[quote=&quot;" . phpbb::$user->lang['VALIDATION_AUTOMOD'] . '&quot;]' . implode("\n\n", $bbcode_results) . "[/quote]\n";
 
 			// Update the queue with the results
 			$queue = $revision->get_queue();
-			$queue->automod_results = $bbcode_results;
-			$queue->submit();
+			$queue->topic_reply($bbcode_results);
 
 			$contrib_tools->remove_temp_files();
 		}


### PR DESCRIPTION
http://www.phpbb.com/bugs/titania/62388

Old behavior:
- Retesting MPV or AutoMOD would update the first post with the new results.
- Repacking a revision would update the first post with results from new revision and create a post stating that the revision had been repacked, with the old results posted below.

New behavior:
- Retesting MPV or AutoMOD creates a new post with the new results. First post does not get touched.
- Repacking a revision now posts the new results in the same post where users are notified of the repackage and first post does not get touched.
