### PR TITLE
Change ColorizeIt JS to link

### DIFF
--- a/titania/styles/default/template/common/contribution_details.html
+++ b/titania/styles/default/template/common/contribution_details.html
@@ -1,18 +1,3 @@
-<!-- IF U_COLORIZEIT -->
-<!--[if lte IE 8]><script type="text/javascript">var clrOldIE = true;</script><![endif]-->
-<script type="text/javascript">
-// <![CDATA[
-	
-	function ColorizeIt(url)
-	{
-	    $('#colorizeit-container').show();
-	    $('#colorizeit-content').html('<iframe src="' + url + '" style="border-width: 0; width: 100%; height: ' + (typeof(clrOldIE) == 'boolean' ? 300 : 900) + 'px;"></iframe>');
-	}
-
-// ]]>
-</script>
-<!-- ENDIF -->
-
 <div class="container">
 	<div class="inner"><span class="corners-top main-corners"><span></span></span>
 
@@ -37,7 +22,7 @@
 				</div>
 				<!-- IF U_COLORIZEIT -->
                     <div class="colorizeit-button">
-                        <a class="colorizeit-main" href="#colorizeit-editor" onclick="ColorizeIt('{U_COLORIZEIT}');" title="{L_COLORIZEIT_DOWNLOAD_STYLE} {CONTRIB_NAME}"></a>
+                        <a class="colorizeit-main" href="{U_COLORIZEIT}" target="_blank" title="{L_COLORIZEIT_DOWNLOAD_STYLE} {CONTRIB_NAME}"></a>
                     </div>
 				<!-- ENDIF -->
 			<!-- ENDIF -->
@@ -180,17 +165,6 @@
 		<!-- ENDIF -->
 	<span class="corners-bottom main-corners"><span></span></span></div>
 </div>
-
-<!-- IF U_COLORIZEIT -->
-<div class="clear"></div>
-<div class="container" id="colorizeit-container" style="display: none;">
-	<div class="inner"><span class="corners-top main-corners"><span></span></span>
-	    <a name="colorizeit-editor"></a>
-	    <div id="colorizeit-content">
-	    </div>
-    <span class="corners-bottom main-corners"><span></span></span></div>
-</div>
-<!-- ENDIF -->
 
 <div class="clear"></div>
 


### PR DESCRIPTION
As of recently Firefox does not allow http iframes in https documents. phpbb.com uses https, colorizeit.com uses http, so editing colors is no longer possible with Firefox. I think other browsers will add such security measure later as well because it does make sense.

This PR removes JavaScript and opens link in new window instead.
