### PR TITLE
[ticket/661] Provide a way to get list of approved contributions

### DIFF
--- a/config/routes/general.yml
+++ b/config/routes/general.yml
@@ -18,6 +18,12 @@ phpbb.titania.all_contribs:
     pattern: /contributions/all
     defaults: { _controller: phpbb.titania.controller.all_contribs:display_all_contributions }
 
+phpbb.titania.get_all_contribs:
+    pattern: /contributions/get/{type}
+    defaults: { _controller: phpbb.titania.controller.all_contribs:get_all_contributions, type: all }
+    requirements:
+        type: all|mod|extension|style|converter|official_tool|bbcode|bridge|translation
+
 phpbb.titania.author:
     pattern: /author/{author}/{page}
     defaults: { _controller: phpbb.titania.controller.author:base, page: details }

--- a/controller/all_contribs.php
+++ b/controller/all_contribs.php
@@ -90,4 +90,18 @@ class all_contribs
 		$data['sort']->set_url($this->helper->route('phpbb.titania.all_contribs'));
 		$this->template->assign_var('U_CANONICAL', $data['sort']->build_canonical());
 	}
+
+	/**
+	 * Get the list of contributions in JSON format.
+	 *
+	 * @param string $type	Contrib type URL identifier.
+	 *
+	 * @return \Symfony\Component\HttpFoundation\JsonResponse
+	 */
+	public function get_all_contributions($type)
+	{
+		$contribs = \contribs_overlord::get_contribs_list($type);
+
+		return new \Symfony\Component\HttpFoundation\JsonResponse($contribs);
+	}
 }


### PR DESCRIPTION
Users really need the official feature to get the list of validated contributions.

The feature was created for further integration with other tools such as Upload Extensions.

Implemented features:
* Ability to get a list of contributions of a special type.
* Ability to get a full list of all contributions grouped by their types.
* Ability to catch different contributions that have the same name: contributions are caught by their IDs, not by their names.

Further possible improvements to do:
* Group contributions by minor phpBB version numbers (3.1, 3.2 and so on), not by full version numbers (3.1.2, 3.1.3 etc.).
* Allow list downloads for specific phpBB versions (only for 3.1, only for 3.2 etc.).
* Add short text descriptions for contributions.
* Add checksums.
* Allow limited downloads (by small portions).

[CUSTDB-661]