### PR TITLE
Do not allow submission of new MODs

### DIFF
--- a/includes/types/mod.php
+++ b/includes/types/mod.php
@@ -102,7 +102,7 @@ class titania_type_mod extends titania_type_base
 		{
 			// Can submit a mod
 			case 'submit' :
-				return false;
+				return false; // Disabled MODs due to 3.0.x EOM
 			break;
 
 			// Can view the mod queue discussion

--- a/includes/types/mod.php
+++ b/includes/types/mod.php
@@ -102,7 +102,7 @@ class titania_type_mod extends titania_type_base
 		{
 			// Can submit a mod
 			case 'submit' :
-				return true;
+				return false;
 			break;
 
 			// Can view the mod queue discussion


### PR DESCRIPTION
This should make it so people can no longer submit new MODs (the Modification option will no longer be visible to them when creating a new contribution, but they can still submit new revisions to validated MODs). @prototech 