### PR TITLE
Replace calls to undefined function trigger_back by triger_error

### DIFF
--- a/includes/manage_tools/fix_left_right_ids.php
+++ b/includes/manage_tools/fix_left_right_ids.php
@@ -46,11 +46,11 @@ class fix_left_right_ids
 
 		if ($changes_made)
 		{
-			trigger_back('LEFT_RIGHT_IDS_FIX_SUCCESS');
+			trigger_error('LEFT_RIGHT_IDS_FIX_SUCCESS');
 		}
 		else
 		{
-			trigger_back('LEFT_RIGHT_IDS_NO_CHANGE');
+			trigger_error('LEFT_RIGHT_IDS_NO_CHANGE');
 		}
 	}
 

--- a/includes/manage_tools/resync_contrib_count.php
+++ b/includes/manage_tools/resync_contrib_count.php
@@ -55,7 +55,7 @@ class resync_contrib_count
 
 		if (!sizeof($types))
 		{
-			trigger_back('RESYNC_CONTRIB_COUNT_COMPLETE');
+			trigger_error('RESYNC_CONTRIB_COUNT_COMPLETE');
 		}
 
 		// Reset counts to 0
@@ -132,7 +132,7 @@ class resync_contrib_count
 
 		if (($start + $limit) >= $total)
 		{
-			trigger_back('RESYNC_CONTRIB_COUNT_COMPLETE');
+			trigger_error('RESYNC_CONTRIB_COUNT_COMPLETE');
 		}
 		else
 		{

--- a/includes/manage_tools/resync_dotted_topics.php
+++ b/includes/manage_tools/resync_dotted_topics.php
@@ -68,6 +68,6 @@ class resync_dotted_topics
 		}
 
 
-		trigger_back('RESYNC_DOTTED_TOPICS_COMPLETE');
+		trigger_error('RESYNC_DOTTED_TOPICS_COMPLETE');
 	}
 }

--- a/includes/manage_tools/update_release_topics.php
+++ b/includes/manage_tools/update_release_topics.php
@@ -58,7 +58,7 @@ class update_release_topics
 
 		if (!sizeof($types))
 		{
-			trigger_back('UPDATE_RELEASE_TOPICS_COMPLETE');
+			trigger_error('UPDATE_RELEASE_TOPICS_COMPLETE');
 		}
 
 		$sql = 'SELECT COUNT(contrib_id) AS cnt FROM ' . TITANIA_CONTRIBS_TABLE . '
@@ -142,7 +142,7 @@ class update_release_topics
 
 		if (($start + $limit) >= $total)
 		{
-			trigger_back('UPDATE_RELEASE_TOPICS_COMPLETE');
+			trigger_error('UPDATE_RELEASE_TOPICS_COMPLETE');
 		}
 		else
 		{


### PR DESCRIPTION
Since that all messages in the administration of Titania are simple message without back link, trigger_error can be used.