### PR TITLE
Allow FAQ postbody to span 100%

### DIFF
--- a/styles/prosilver/template/contributions/contribution_faq.html
+++ b/styles/prosilver/template/contributions/contribution_faq.html
@@ -100,7 +100,7 @@
 <!-- ELSEIF S_DETAILS -->
 	<div id="p{posts.POST_ID}" class="post container">
 		<div class="inner">
-			<div class="postbody">
+			<div class="postbody" style="width:100%">
 				<h3>{FAQ_SUBJECT}
 				<!-- IF S_ACCESS_TEAMS --><img src="{T_TITANIA_THEME_PATH}/{S_USER_LANG}/icon_access_teams.png" alt="{L_ACCESS_LIMIT_TEAMS}" title="{L_ACCESS_LIMIT_TEAMS}" />
 				<!-- ELSEIF S_ACCESS_AUTHORS--><img src="{T_TITANIA_THEME_PATH}/{S_USER_LANG}/icon_access_author.png" alt="{L_ACCESS_LIMIT_AUTHORS}" title="{L_ACCESS_LIMIT_AUTHORS}" /><!-- ENDIF --></h3>

--- a/styles/prosilver/template/contributions/contribution_faq.html
+++ b/styles/prosilver/template/contributions/contribution_faq.html
@@ -100,7 +100,7 @@
 <!-- ELSEIF S_DETAILS -->
 	<div id="p{posts.POST_ID}" class="post container">
 		<div class="inner">
-			<div class="postbody" style="width:100%">
+			<div class="postbody full">
 				<h3>{FAQ_SUBJECT}
 				<!-- IF S_ACCESS_TEAMS --><img src="{T_TITANIA_THEME_PATH}/{S_USER_LANG}/icon_access_teams.png" alt="{L_ACCESS_LIMIT_TEAMS}" title="{L_ACCESS_LIMIT_TEAMS}" />
 				<!-- ELSEIF S_ACCESS_AUTHORS--><img src="{T_TITANIA_THEME_PATH}/{S_USER_LANG}/icon_access_author.png" alt="{L_ACCESS_LIMIT_AUTHORS}" title="{L_ACCESS_LIMIT_AUTHORS}" /><!-- ENDIF --></h3>


### PR DESCRIPTION
The FAQ's are scrunched down to 76% to make room for profiles, but there are no profiles to display. So this is just a remnant of relying on prosilver styling/classes. There's no reason the FAQs can't span the whole width of the post content area, so this little fix allows for that.