### PR TITLE
Add "Validated for: version #" to download button info

### DIFF
--- a/language/en/contributions.php
+++ b/language/en/contributions.php
@@ -109,6 +109,7 @@ $lang = array_merge($lang, array(
 	'DOWNLOADS_TOTAL'						=> 'Total Downloads',
 	'DOWNLOADS_VERSION'						=> 'Version Downloads',
 	'DOWNLOAD_CHECKSUM'						=> 'MD5 checksum',
+	'DOWNLOAD_VALIDATION_VERSION'			=> 'Validated for',
 	'DUPLICATE_AUTHORS'						=> 'You have the following authors listed as both active and non-active (they can not be both): %s',
 
 	'EDIT_REVISION'							=> 'Edit Revision',

--- a/styles/prosilver/template/common/contribution_details.html
+++ b/styles/prosilver/template/common/contribution_details.html
@@ -35,6 +35,12 @@
 							<dt>{L_FILESIZE}{L_COLON}</dt>
 							<dd>{downloads.SIZE}<dd>
 						</dl>
+						<!-- IF downloads.PHPBB_VERSION -->
+						<dl>
+							<dt>{L_DOWNLOAD_VALIDATION_VERSION}{L_COLON}</dt>
+							<dd>phpBB {downloads.PHPBB_VERSION}</dd>
+						</dl>
+						<!-- ENDIF -->
 						<dl>
 							<dt>{L_DOWNLOAD_CHECKSUM}{L_COLON}</dt>
 							<dd>{downloads.CHECKSUM}</dd>


### PR DESCRIPTION
This adds to the download button info box that appears a little text:
Validated for:
phpBB 3.1.X

There are always people who think the version we display in the download button means that the contribution is ONLY for that version of phpBB. I am hoping this little addition of info makes it clearer that the version of phpBB displayed is not a rule, it's just our way of showing what version of phpBB we used when validating the contrib.

![screen shot 2015-12-03 at 9 35 01 am](https://cloud.githubusercontent.com/assets/303711/11568476/316ce050-99a1-11e5-8ef0-672bff0eba08.png)
