### PR TITLE
Improves the regex to fix common error in composer.json

### DIFF
--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -293,7 +293,7 @@ class type extends base
 				$data['require']['phpbb/phpbb'] = $data['extra']['soft-require']['phpbb/phpbb'];
 
 				// fix common error (<=3.2.*@dev)
-				$data['require']['phpbb/phpbb'] = preg_replace('/(<|<=|~|\^|>|>=)([0-9]+(\.[0-9]+)?)\.\*/', '$1$2', $data['require']['phpbb/phpbb']);
+				$data['require']['phpbb/phpbb'] = preg_replace('/(<|<=|~|\^|>|>=)([0-9]+(\.[0-9]+)?)\.[*x]/', '$1$2', $data['require']['phpbb/phpbb']);
 			}
 		}
 


### PR DESCRIPTION
Some extensions are using `>=3.1.x` and not only `>=3.1.*`