### PR TITLE
Prevent $params variable from being anything other than an array

### DIFF
--- a/controller/search.php
+++ b/controller/search.php
@@ -543,7 +543,7 @@ class search
 				return '';
 		}
 
-		return $this->helper->route($controller, $params);
+		return $this->helper->route($controller, is_array($params) ? $params : array());
 	}
 
 	/**


### PR DESCRIPTION
This should resolve "Catchable fatal error: Argument 2 passed to phpbb\titania\controller\helper::route() must be of the type array, boolean given, called in /var/www/www.phpbb.com/website-current/old/community/ext/phpbb/titania/controller/search.php on line 546 and defined in /var/www/www.phpbb.com/website-current/old/community/ext/phpbb/titania/controller/helper.php on line 39"