### PR TITLE
Remove IN_PHPBB check

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -11,14 +11,6 @@
 *
 */
 
-/**
- * @ignore
- */
-if (!defined('IN_PHPBB'))
-{
-	exit;
-}
-
 // Contribution types
 define('TITANIA_TYPE_MOD', 1);
 define('TITANIA_TYPE_STYLE', 2);


### PR DESCRIPTION
This is unnecessary and because this file is autoloaded, it means this file will kill anything (like phpunit) that doesn't have this constant defined.