### PR TITLE
Fix quickview title overflow issues

### DIFF
--- a/styles/prosilver/theme/common.css
+++ b/styles/prosilver/theme/common.css
@@ -423,6 +423,10 @@ a.screenshot img, img.screenshot {
 .quickview-title {
 	font-size: 1.2em;
 	position: relative;
+	display: block;
+	text-overflow: ellipsis;
+	overflow-x: hidden;
+	white-space: nowrap;
 }
 
 .quickview-preview {


### PR DESCRIPTION
Items in CDB with really long titles (like totally inappropriate titles that aren't really titles but in fact descriptions, but what can you do) break the flow and layout of the CDB.

This PR fixes that by truncating and using an ellipsis on long-winded titles, so they won't break our layout in the way seen below:

![screen shot 2016-10-24 at 11 57 39 pm](https://cloud.githubusercontent.com/assets/303711/19675856/ab2034f6-9a45-11e6-9d44-6803e2c57a4b.png)