### PR TITLE
Topic icons link to 1st unread post

### DIFF
--- a/styles/prosilver/template/common/topic_list.html
+++ b/styles/prosilver/template/common/topic_list.html
@@ -56,6 +56,7 @@
 		<li class="row<!-- IF topics.S_ROW_COUNT is even --> bg1<!-- ELSE --> bg2<!-- ENDIF --><!-- IF topics.S_POST_STICKY --> sticky<!-- ENDIF --><!-- IF topics.S_TOPIC_REPORTED --> reported<!-- ENDIF -->">
 			<dl class="row-item {topics.FOLDER_STYLE}">
 				<dt title="{topics.FOLDER_IMG_ALT}"<!-- IF topics.S_TOPIC_PROGRESS --> class="queue_progress"<!-- ELSEIF topics.S_TESTED -->class="queue_tested"<!-- ENDIF -->>
+					<!-- IF topics.S_UNREAD_TOPIC and not S_IS_BOT --><a href="{topics.U_NEWEST_POST}" class="icon-link"></a><!-- ENDIF -->
 					<div class="list-inner">
 						<!-- IF topics.S_ACCESS_TEAMS -->
 						<img src="{T_TITANIA_THEME_PATH}/images/icon_access_teams.png" class="icon" alt="{L_ACCESS_LIMIT_TEAMS}" title="{L_ACCESS_LIMIT_TEAMS}" />


### PR DESCRIPTION
Topic icons should open 1st unread post, just as happens in pro silver forums.