### PR TITLE
Fix output of EPV

### DIFF
--- a/contribution/extension/prevalidator.php
+++ b/contribution/extension/prevalidator.php
@@ -24,6 +24,7 @@ class prevalidator
 	 *
 	 * @param string $directory		Directory where extracted revision is located
 	 * @return string
+	 * @throws \InvalidArgumentException
 	 */
 	public function run_epv($directory)
 	{
@@ -33,46 +34,42 @@ class prevalidator
 		$runner->runTests();
 
 		// Write a empty line
-		$output->writeLn('');
+		$output->writeln('');
 
-		$found_msg = ' ';
-		$found_msg .= 'Fatal: ' . $output->getMessageCount(Output::FATAL);
-		$found_msg .= ', Error: ' . $output->getMessageCount(Output::ERROR);
-		$found_msg .= ', Warning: ' . $output->getMessageCount(Output::WARNING);
-		$found_msg .= ', Notice: ' . $output->getMessageCount(Output::NOTICE);
-		$found_msg .= ' ';
+		$found_msg = implode(', ', array(
+			'Fatal: ' . $output->getMessageCount(Output::FATAL),
+			'Error: ' . $output->getMessageCount(Output::ERROR),
+			'Warning: ' . $output->getMessageCount(Output::WARNING),
+			'Notice: ' . $output->getMessageCount(Output::NOTICE),
+		));
 
 		if ($output->getMessageCount(Output::FATAL) > 0 || $output->getMessageCount(Output::ERROR) > 0 || $output->getMessageCount(Output::WARNING) > 0)
 		{
-			$output->writeln('<fatal>' . str_repeat(' ', strlen($found_msg)) . '</fatal>');
-			$output->writeln('<fatal> Validation: [b][color=#A91F1F]FAILED[/color][/b]' . str_repeat(' ', strlen($found_msg) - 19) . '</fatal>');
-			$output->writeln('<fatal>' . $found_msg . '</fatal>');
-			$output->writeln('<fatal>' . str_repeat(' ', strlen($found_msg)) . '</fatal>');
-			$output->writeln('');
+			$output->writeln('Validation: [b][color=#A91F1F]FAILED[/color][/b]');
 		}
 		else
 		{
-			$output->writeln('<success>PASSED: ' . $found_msg . '</success>');
+			$output->writeln('Validation: [b][color=#00BF40]PASSED[/color][/b]');
 		}
 
-		$output->writeln("<info>Test results for extension:</info>");
+		$output->writeln($found_msg);
+		$output->writeln('');
+
+		$output->writeln('Test results for extension:');
 		$messages = $output->getMessages();
 
 		if (!empty($messages))
 		{
 			$output->writeln('[list]');
-		}
-		foreach ($messages as $msg)
-		{
-			$output->writeln('[*]' . (string) $msg);
-		}
-		if (!empty($messages))
-		{
+			foreach ($messages as $msg)
+			{
+				$output->writeln('[*]' . (string) $msg);
+			}
 			$output->writeln('[/list]');
 		}
 		else
 		{
-			$output->writeln("<success>[color=#00BF40]No issues found[/color] </success>");
+			$output->writeln('[color=#00BF40]No issues found[/color]');
 		}
 
 		return $this->clear_formatting($int_output->getBuffer());

--- a/contribution/extension/prevalidator.php
+++ b/contribution/extension/prevalidator.php
@@ -75,6 +75,18 @@ class prevalidator
 			$output->writeln("<success>[color=#00BF40]No issues found[/color] </success>");
 		}
 
-		return $int_output->getBuffer();
+		return $this->clear_formatting($int_output->getBuffer());
+	}
+
+	/**
+	 * Remove EPV CLI style formatting from the message
+	 *
+	 * @param string $text
+	 *
+	 * @return string
+	 */
+	protected function clear_formatting($text)
+	{
+		return preg_replace('/<\/?(success|notice|noticebg|warning|error|fatal|info)b?>/', '', $text);
 	}
 }

--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -149,6 +149,8 @@ class type extends base
 		$uid = $bitfield = $flags = false;
 		generate_text_for_storage($results, $uid, $bitfield, $flags, true, true, true);
 
+		$results = htmlspecialchars_decode($results);
+
 		// Add the prevalidator results to the queue
 		$queue = $revision->get_queue();
 		$queue->mpv_results = $results;

--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -149,8 +149,6 @@ class type extends base
 		$uid = $bitfield = $flags = false;
 		generate_text_for_storage($results, $uid, $bitfield, $flags, true, true, true);
 
-		$results = htmlspecialchars_decode($results);
-
 		// Add the prevalidator results to the queue
 		$queue = $revision->get_queue();
 		$queue->mpv_results = $results;


### PR DESCRIPTION
Fix an issue in phpBB 3.2 where EPV output, which contains CLI formatting such as `<success>` was now being encoded to HTML entities, and thus rendering `<success>`, e.g.

![unspecified](https://cloud.githubusercontent.com/assets/303711/21701747/5f6d0692-d35c-11e6-99df-a64937697892.png)
