### PR TITLE
Include constants during enabling

### DIFF
--- a/ext.php
+++ b/ext.php
@@ -15,4 +15,14 @@ namespace phpbb\titania;
 
 class ext extends \phpbb\extension\base
 {
+	public function is_enableable()
+	{
+		if (!defined('TITANIA_SUPPORT'))
+		{
+			$php_ext = $this->container->getParameter('core.php_ext');
+			include($this->extension_path . 'includes/constants.' . $php_ext);
+		}
+
+		return true;
+	}
 }


### PR DESCRIPTION
During enabling the ["autoload"](https://github.com/phpbb/customisation-db/blob/3.2.x/composer.json#L70) is not handled which is why the constants need to be included manually. This should fix the error reported here: https://www.phpbb.com/community/viewtopic.php?p=14613446#p14613446