### PR TITLE
Move defined constants to class constants

### DIFF
--- a/attachment/attachment.php
+++ b/attachment/attachment.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\attachment;
 
 use phpbb\titania\access;
+use phpbb\titania\ext;
 
 class attachment extends \phpbb\titania\entity\database_base
 {
@@ -619,7 +620,7 @@ class attachment extends \phpbb\titania\entity\database_base
 	 */
 	public function set_preview()
 	{
-		if (!$this->is_type(TITANIA_SCREENSHOT))
+		if (!$this->is_type(ext::TITANIA_SCREENSHOT))
 		{
 			return false;
 		}

--- a/attachment/operator.php
+++ b/attachment/operator.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\attachment;
 
 use phpbb\titania\access;
+use phpbb\titania\ext;
 
 class operator
 {
@@ -287,7 +288,7 @@ class operator
 	 * Load attachments by id.
 	 *
 	 * Note that this will not check the object type or id.
-	 * 
+	 *
 	 * @param array $ids
 	 * @return $this
 	 */
@@ -472,7 +473,7 @@ class operator
 				$this->template->assign_block_vars($template_block, $vars);
 			}
 
-			if ($attach->is_preview() && $attach->is_type(TITANIA_SCREENSHOT))
+			if ($attach->is_preview() && $attach->is_type(ext::TITANIA_SCREENSHOT))
 			{
 				$this->template->assign_block_vars('preview', $vars);
 			}

--- a/attachment/uploader.php
+++ b/attachment/uploader.php
@@ -16,6 +16,7 @@ namespace phpbb\titania\attachment;
 use phpbb\files\upload;
 use phpbb\request\request_interface;
 use phpbb\titania\access;
+use phpbb\titania\ext;
 
 class uploader
 {
@@ -350,7 +351,7 @@ class uploader
 			'S_PLUPLOAD_ENABLED'			=> $this->use_plupload,
 			'S_SET_CUSTOM_ORDER'			=> $this->set_custom_order,
 			'S_UPLOADER_KEY'				=> generate_link_hash('uploader_key'),
-			'SELECT_PREVIEW'				=> $this->object_type == TITANIA_SCREENSHOT,
+			'SELECT_PREVIEW'				=> $this->object_type == ext::TITANIA_SCREENSHOT,
 			'SELECT_REVIEW_VAR' 			=> 'set_preview_file' . $this->object_type,
 		));
 
@@ -400,7 +401,7 @@ class uploader
 					),
 			));
 
-			if ($attach->is_type(TITANIA_SCREENSHOT))
+			if ($attach->is_type(ext::TITANIA_SCREENSHOT))
 			{
 				$output = array_merge($output, array(
 					'U_MOVE_UP'		=> $this->path_helper->append_url_params(

--- a/cache/service.php
+++ b/cache/service.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\cache;
 
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use phpbb\titania\versions;
 
 class service extends \phpbb\cache\service
@@ -264,7 +265,7 @@ class service extends \phpbb\cache\service
 		{
 			// If approved, or new and doesn't require approval, or the user is viewing their own, or permission to view non-validated, add them to the list
 			if ($user->data['user_id'] == $user_id ||
-				in_array($data['status'], array(TITANIA_CONTRIB_APPROVED, TITANIA_CONTRIB_DOWNLOAD_DISABLED)) ||
+				in_array($data['status'], array(ext::TITANIA_CONTRIB_APPROVED, ext::TITANIA_CONTRIB_DOWNLOAD_DISABLED)) ||
 				$types->get($data['type'])->acl_get('view') ||
 				$types->get($data['type'])->acl_get('moderate'))
 			{

--- a/composer.json
+++ b/composer.json
@@ -65,8 +65,5 @@
         "soft-require": {
             "phpbb/phpbb": "3.1.*@dev"
         }
-    },
-    "autoload": {
-        "files": ["includes/constants.php"]
     }
 }

--- a/config.example.php
+++ b/config.example.php
@@ -19,6 +19,8 @@ if (!defined('IN_PHPBB'))
 	exit;
 }
 
+use phpbb\titania\ext;
+
 $config = array(
 	/**
 	* phpBB versions array
@@ -116,7 +118,7 @@ $config = array(
 	/**
 	* If the type of post made is in this array we will increment their postcount as posts are made within titania
 	*/
-	'increment_postcount'	=> array(TITANIA_SUPPORT),
+	'increment_postcount'	=> array(ext::TITANIA_SUPPORT),
 
 	/**
 	* Note: There are still more configuration settings!

--- a/config/config.php
+++ b/config/config.php
@@ -13,6 +13,8 @@
 
 namespace phpbb\titania\config;
 
+use phpbb\titania\ext;
+
 class config extends \phpbb\titania\entity\base
 {
 	/** @var \phpbb\config\config */
@@ -54,8 +56,8 @@ class config extends \phpbb\titania\entity\base
 			'language_path'				=> array('default' => $this->ext_root_path . 'language/'),
 			'table_prefix'				=> array('default' => 'cdb_'),
 
-			// Increment the user's post count?  Array of the post_types for which we will increment the post count
-			'increment_postcount'		=> array('default' => array(TITANIA_SUPPORT)),
+			// Increment the user's post count? Array of the post_types for which we will increment the post count
+			'increment_postcount'		=> array('default' => array(ext::TITANIA_SUPPORT)),
 
 			// Path to demo board we will install styles on
 			'demo_style_path'			=> array('default' => array(
@@ -162,57 +164,57 @@ class config extends \phpbb\titania\entity\base
 			)),
 
 			// ColorizeIt
-			'colorizeit'                => array('default' => ''),
-			'colorizeit_url'            => array('default' => 'www.colorizeit.com'),
-			'colorizeit_auth'           => array('default' => 'HEADER'),
-			'colorizeit_var'            => array('default' => 'X-Colorizeit'),
-			'colorizeit_value'          => array('default' => '1'),
+			'colorizeit'		=> array('default' => ''),
+			'colorizeit_url'	=> array('default' => 'www.colorizeit.com'),
+			'colorizeit_auth'	=> array('default' => 'HEADER'),
+			'colorizeit_var'	=> array('default' => 'X-Colorizeit'),
+			'colorizeit_value'	=> array('default' => '1'),
 
 			/**
 			 * Attachments -------
 			 */
 			'upload_max_filesize'		=> array('default' => array(
-				TITANIA_CONTRIB		=> 10485760, // 10 MiB
-				TITANIA_SCREENSHOT	=> 524288, // 512 Kib
-				TITANIA_TRANSLATION	=> 1048576, // 1 Mib
-				TITANIA_CLR_SCREENSHOT  => 131072, // 128 Kib
+				ext::TITANIA_CONTRIB			=> 10485760,	// 10 MiB
+				ext::TITANIA_SCREENSHOT			=> 524288,		// 512 Kib
+				ext::TITANIA_TRANSLATION		=> 1048576,		// 1 Mib
+				ext::TITANIA_CLR_SCREENSHOT		=> 131072,		// 128 Kib
 			)),
 
 			// Extensions allowed
 			'upload_allowed_extensions'	=> array('default' => array(
-				TITANIA_CONTRIB				=> array('zip'),
-				TITANIA_SCREENSHOT			=> array('jpg', 'jpeg', 'gif', 'png', 'tif', 'tiff'),
-				TITANIA_TRANSLATION			=> array('zip'),
-				TITANIA_SUPPORT				=> array(
+				ext::TITANIA_CONTRIB			=> array('zip'),
+				ext::TITANIA_SCREENSHOT			=> array('jpg', 'jpeg', 'gif', 'png', 'tif', 'tiff'),
+				ext::TITANIA_TRANSLATION		=> array('zip'),
+				ext::TITANIA_SUPPORT			=> array(
 					'zip', 'tar', 'gz', '7z', 'bz2', 'gtar',
 					'jpg', 'jpeg', 'gif', 'png', 'tif', 'tiff'
 				),
-				TITANIA_QUEUE				=> array(
+				ext::TITANIA_QUEUE				=> array(
 					'zip', 'tar', 'gz', '7z', 'bz2', 'gtar',
 					'jpg', 'jpeg', 'gif', 'png', 'tif', 'tiff'
 				),
-				TITANIA_QUEUE_DISCUSSION	=> array(
+				ext::TITANIA_QUEUE_DISCUSSION	=> array(
 					'zip', 'tar', 'gz', '7z', 'bz2', 'gtar',
 					'jpg', 'jpeg', 'gif', 'png', 'tif', 'tiff'
 				),
-				TITANIA_FAQ					=> array(
+				ext::TITANIA_FAQ				=> array(
 					'zip', 'tar', 'gz', '7z', 'bz2', 'gtar',
 					'jpg', 'jpeg', 'gif', 'png', 'tif', 'tiff'
 				),
 				// ColorizeIt sample image
-				TITANIA_CLR_SCREENSHOT      => array('gif'),
+				ext::TITANIA_CLR_SCREENSHOT		=> array('gif'),
 			)),
 
 			// Attachment directory names
 			'upload_directory'	=> array('default' => array(
-				TITANIA_CONTRIB				=> 'revisions',
-				TITANIA_SCREENSHOT			=> 'screenshots',
-				TITANIA_TRANSLATION			=> 'translations',
-				TITANIA_SUPPORT				=> 'support',
-				TITANIA_QUEUE				=> 'queue',
-				TITANIA_QUEUE_DISCUSSION	=> 'queue_discussion',
-				TITANIA_FAQ					=> 'faq',
-				TITANIA_CLR_SCREENSHOT      => 'colorizeit',
+				ext::TITANIA_CONTRIB			=> 'revisions',
+				ext::TITANIA_SCREENSHOT			=> 'screenshots',
+				ext::TITANIA_TRANSLATION		=> 'translations',
+				ext::TITANIA_SUPPORT			=> 'support',
+				ext::TITANIA_QUEUE				=> 'queue',
+				ext::TITANIA_QUEUE_DISCUSSION	=> 'queue_discussion',
+				ext::TITANIA_FAQ				=> 'faq',
+				ext::TITANIA_CLR_SCREENSHOT		=> 'colorizeit',
 			)),
 
 			// Remove unsubmitted revisions and attachments

--- a/contribution/bbcode/type.php
+++ b/contribution/bbcode/type.php
@@ -15,11 +15,8 @@ namespace phpbb\titania\contribution\bbcode;
 
 use phpbb\auth\auth;
 use phpbb\request\request_interface;
-use phpbb\titania\attachment\attachment;
 use phpbb\titania\config\config as ext_config;
 use phpbb\titania\contribution\type\base;
-use phpbb\titania\entity\package;
-use phpbb\titania\url\url;
 use phpbb\user;
 
 class type extends base

--- a/contribution/extension/prevalidator.php
+++ b/contribution/extension/prevalidator.php
@@ -13,8 +13,8 @@
 
 namespace phpbb\titania\contribution\extension;
 
-use Phpbb\Epv\Output\Output;
 use Phpbb\Epv\Output\HtmlOutput;
+use Phpbb\Epv\Output\Output;
 use Phpbb\Epv\Tests\TestRunner;
 
 class prevalidator

--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -14,12 +14,11 @@
 namespace phpbb\titania\contribution\extension;
 
 use phpbb\auth\auth;
+use phpbb\template\template;
 use phpbb\titania\attachment\attachment;
 use phpbb\titania\config\config as ext_config;
 use phpbb\titania\contribution\type\base;
 use phpbb\titania\entity\package;
-use phpbb\titania\url\url;
-use phpbb\template\template;
 use phpbb\user;
 
 class type extends base
@@ -299,7 +298,7 @@ class type extends base
 			// fix common error (<=3.2.*@dev, >=3.1.x)
 			$data['require']['phpbb/phpbb'] = preg_replace('/(<|<=|~|\^|>|>=)([0-9]+(\.[0-9]+)?)\.[*x]/', '$1$2', $data['require']['phpbb/phpbb']);
 		}
-		
+
 		return $data;
 	}
 

--- a/contribution/mod/type.php
+++ b/contribution/mod/type.php
@@ -14,13 +14,11 @@
 namespace phpbb\titania\contribution\mod;
 
 use phpbb\auth\auth;
-use phpbb\db\driver\driver_interface as db_driver_interface;
+use phpbb\template\template;
 use phpbb\titania\attachment\attachment;
 use phpbb\titania\config\config as ext_config;
 use phpbb\titania\contribution\type\base;
 use phpbb\titania\entity\package;
-use phpbb\titania\url\url;
-use phpbb\template\template;
 use phpbb\user;
 
 class type extends base

--- a/contribution/style/demo/demo.php
+++ b/contribution/style/demo/demo.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\contribution\style\demo;
 
 use phpbb\exception\http_exception;
+use phpbb\titania\ext;
 
 /**
  * Class that handles displaying styles demo
@@ -136,7 +137,7 @@ class demo
 	public function load_styles()
 	{
 		$sql_array = array(
-			'SELECT'	=> 'c.contrib_id, c.contrib_name, c.contrib_name_clean, c.contrib_user_id, c.contrib_demo, 
+			'SELECT'	=> 'c.contrib_id, c.contrib_name, c.contrib_name_clean, c.contrib_user_id, c.contrib_demo,
 							s.attachment_id AS thumb_id, s.thumbnail, MAX(r.revision_id) AS revision_id,
 							u.username, u.username_clean, u.user_colour, cat.category_name',
 			'FROM'		=> array(
@@ -151,12 +152,12 @@ class demo
 					'ON'	=> 'c.contrib_id = s.object_id
 						AND s.is_preview = 1
 						AND s.is_orphan = 0
-						AND object_type = ' . TITANIA_SCREENSHOT,
+						AND object_type = ' . ext::TITANIA_SCREENSHOT,
 				), array (
 					'FROM'	=> array($this->revisions_table => 'r'),
 					'ON'	=> 'c.contrib_id = r.contrib_id
 						AND	r.revision_submitted = 1
-						AND r.revision_status = ' . TITANIA_REVISION_APPROVED,
+						AND r.revision_status = ' . ext::TITANIA_REVISION_APPROVED,
 				), array(
 					'FROM'	=> array($this->contrib_in_categories_table => 'cic'),
 					'ON'	=> 'c.contrib_id = cic.contrib_id',
@@ -169,9 +170,9 @@ class demo
 				),
 			),
 			'WHERE'		=>  'c.contrib_visible = 1
-								AND c.contrib_type = ' . TITANIA_TYPE_STYLE . '
-								AND cat.category_options & ' . TITANIA_CAT_FLAG_DEMO . '
-								AND c.contrib_status =' . TITANIA_CONTRIB_APPROVED . '
+								AND c.contrib_type = ' . ext::TITANIA_TYPE_STYLE . '
+								AND cat.category_options & ' . ext::TITANIA_CAT_FLAG_DEMO . '
+								AND c.contrib_status =' . ext::TITANIA_CONTRIB_APPROVED . '
 								AND c.contrib_demo <> ""
 								AND rp.phpbb_version_branch = ' . (int) $this->phpbb_branch,
 
@@ -253,7 +254,7 @@ class demo
 	 */
 	protected function get_coauthors()
 	{
-		$sql = 'SELECT a.contrib_id, u.user_id, u.username, u.username_clean, u.user_colour 
+		$sql = 'SELECT a.contrib_id, u.user_id, u.username, u.username_clean, u.user_colour
 			FROM ' . $this->contrib_coauthors_table . ' a
 			LEFT JOIN ' . $this->users_table . ' u ON a.user_id = u.user_id
 			WHERE a.active = 1 AND ' . $this->db->sql_in_set('a.contrib_id', array_keys($this->styles));
@@ -271,7 +272,7 @@ class demo
 	 */
 	protected function get_phpbb_versions()
 	{
-		$sql = 'SELECT contrib_id, phpbb_version_branch, phpbb_version_revision 
+		$sql = 'SELECT contrib_id, phpbb_version_branch, phpbb_version_revision
 			FROM ' . $this->revisions_phpbb_table . '
 			WHERE revision_validated = 1 AND ' . $this->db->sql_in_set('revision_id', $this->revisions) . '
 			ORDER BY phpbb_version_revision ASC';
@@ -310,7 +311,7 @@ class demo
 		if (isset($this->styles[$sibling]['contrib_demo']))
 		{
 			$style = new \titania_contribution();
-			$style->set_type(TITANIA_TYPE_STYLE);
+			$style->set_type(ext::TITANIA_TYPE_STYLE);
 			$style->__set_array(array(
 				'contrib_name_clean'	=> $this->styles[$sibling]['contrib_name_clean'],
 				'contrib_demo'			=> $this->styles[$sibling]['contrib_demo'],
@@ -349,7 +350,7 @@ class demo
 
 		$category = '';
 		$style = new \titania_contribution;
-		$style->set_type(TITANIA_TYPE_STYLE);
+		$style->set_type(ext::TITANIA_TYPE_STYLE);
 		$style->options = array('demo' => true);
 
 		foreach ($this->styles as $id => $data)

--- a/contribution/style/type.php
+++ b/contribution/style/type.php
@@ -15,12 +15,11 @@ namespace phpbb\titania\contribution\style;
 
 use phpbb\auth\auth;
 use phpbb\request\request_interface;
+use phpbb\template\template;
 use phpbb\titania\attachment\attachment;
 use phpbb\titania\config\config as ext_config;
 use phpbb\titania\contribution\type\base;
 use phpbb\titania\entity\package;
-use phpbb\titania\url\url;
-use phpbb\template\template;
 use phpbb\user;
 
 class type extends base

--- a/contribution/translation/type.php
+++ b/contribution/translation/type.php
@@ -14,12 +14,11 @@
 namespace phpbb\titania\contribution\translation;
 
 use phpbb\auth\auth;
+use phpbb\template\template;
 use phpbb\titania\attachment\attachment;
 use phpbb\titania\config\config as ext_config;
 use phpbb\titania\contribution\type\base;
 use phpbb\titania\entity\package;
-use phpbb\titania\url\url;
-use phpbb\template\template;
 use phpbb\user;
 
 class type extends base

--- a/controller/author.php
+++ b/controller/author.php
@@ -15,6 +15,7 @@ namespace phpbb\titania\controller;
 
 use phpbb\titania\access;
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 
 class author
 {
@@ -234,7 +235,7 @@ class author
 		{
 			foreach ($this->cache->get_author_contribs($this->author->user_id, $this->types, $this->user) as $contrib_id)
 			{
-				$this->tracking->track(TITANIA_SUPPORT, $contrib_id);
+				$this->tracking->track(ext::TITANIA_SUPPORT, $contrib_id);
 			}
 		}
 
@@ -430,7 +431,7 @@ class author
 
 					foreach ($active_authors as $author)
 					{
-						$this->subscriptions->subscribe(TITANIA_SUPPORT, $contrib->contrib_id, $author);
+						$this->subscriptions->subscribe(ext::TITANIA_SUPPORT, $contrib->contrib_id, $author);
 					}
 				}
 				redirect($contrib->get_url('revision'));

--- a/controller/colorizeit.php
+++ b/controller/colorizeit.php
@@ -13,11 +13,12 @@
 
 namespace phpbb\titania\controller;
 
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use phpbb\request\request_interface;
 use phpbb\titania\access;
 use phpbb\titania\contribution\style\colorizeit_helper;
+use phpbb\titania\ext;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class colorizeit
 {
@@ -180,7 +181,7 @@ class colorizeit
 		if ($id)
 		{
 			$this->attachment = $this->attachments
-				->configure(TITANIA_CONTRIB, 0)
+				->configure(ext::TITANIA_CONTRIB, 0)
 				->load_from_ids(array($id))
 				->get($id)
 			;
@@ -199,7 +200,7 @@ class colorizeit
 	*/
 	protected function check_attachment_auth()
 	{
-		return $this->attachment->object_type == TITANIA_CONTRIB &&
+		return $this->attachment->object_type == ext::TITANIA_CONTRIB &&
 			!$this->attachment->is_orphan &&
 			$this->attachment->attachment_access == access::PUBLIC_LEVEL;
 	}
@@ -219,7 +220,7 @@ class colorizeit
 		$data = $this->db->sql_fetchrow($result);
 		$this->db->sql_freeresult();
 
-		if (!$data || $data['revision_status'] != TITANIA_REVISION_APPROVED)
+		if (!$data || $data['revision_status'] != ext::TITANIA_REVISION_APPROVED)
 		{
 			throw new \Exception('NO_REVISION');
 		}

--- a/controller/contribution/base.php
+++ b/controller/contribution/base.php
@@ -16,6 +16,7 @@ namespace phpbb\titania\controller\contribution;
 use phpbb\titania\access;
 use phpbb\titania\contribution\type\collection as type_collection;
 use phpbb\titania\count;
+use phpbb\titania\ext;
 
 class base
 {
@@ -129,7 +130,7 @@ class base
 		// Count the number of FAQ items to display
 		$flags = count::get_flags($this->access->get_level());
 		$faq_count = count::from_db($this->contrib->contrib_faq_count, $flags);
-		$is_disabled = in_array($this->contrib->contrib_status, array(TITANIA_CONTRIB_CLEANED, TITANIA_CONTRIB_DISABLED));
+		$is_disabled = in_array($this->contrib->contrib_status, array(ext::TITANIA_CONTRIB_CLEANED, ext::TITANIA_CONTRIB_DISABLED));
 
 		/**
 		* Menu Array
@@ -173,7 +174,7 @@ class base
 			$demo_menu = array();
 			$allowed_branches = $this->contrib->type->get_allowed_branches(true);
 			krsort($allowed_branches);
-			$is_external = $this->contrib->contrib_status != TITANIA_CONTRIB_APPROVED || !$this->contrib->options['demo'];
+			$is_external = $this->contrib->contrib_status != ext::TITANIA_CONTRIB_APPROVED || !$this->contrib->options['demo'];
 
 			foreach ($allowed_branches as $branch => $name)
 			{

--- a/controller/contribution/contribution.php
+++ b/controller/contribution/contribution.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\controller\contribution;
 
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -139,11 +140,11 @@ class contribution extends base
 		}
 
 		// Set tracking
-		$this->tracking->track(TITANIA_CONTRIB, $this->contrib->contrib_id);
+		$this->tracking->track(ext::TITANIA_CONTRIB, $this->contrib->contrib_id);
 
 		// Subscriptions
 		$this->subscriptions->handle_subscriptions(
-			TITANIA_CONTRIB,
+			ext::TITANIA_CONTRIB,
 			$this->contrib->contrib_id,
 			$this->contrib->get_url(),
 			'SUBSCRIBE_CONTRIB'
@@ -171,8 +172,8 @@ class contribution extends base
 	{
 		$this->load_contrib($contrib_type, $contrib);
 		$can_use_demo =
-			$this->contrib->contrib_status == TITANIA_CONTRIB_APPROVED &&
-			$this->contrib->contrib_type == TITANIA_TYPE_STYLE &&
+			$this->contrib->contrib_status == ext::TITANIA_CONTRIB_APPROVED &&
+			$this->contrib->contrib_type == ext::TITANIA_TYPE_STYLE &&
 			$this->contrib->options['demo']
 		;
 
@@ -210,7 +211,7 @@ class contribution extends base
 	{
 		$sql = 'SELECT *
 			FROM ' . TITANIA_TOPICS_TABLE . '
-			WHERE topic_type = ' . TITANIA_QUEUE_DISCUSSION . '
+			WHERE topic_type = ' . ext::TITANIA_QUEUE_DISCUSSION . '
 			AND parent_id = ' . $this->contrib->contrib_id;
 		$result = $this->db->sql_query($sql);
 		$row = $this->db->sql_fetchrow($result);

--- a/controller/contribution/faq.php
+++ b/controller/contribution/faq.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\controller\contribution;
 
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class faq extends base
@@ -92,13 +93,13 @@ class faq extends base
 		$this->faq->increase_views_counter();
 
 		// Tracking
-		$this->tracking->track(TITANIA_FAQ, $this->id);
+		$this->tracking->track(ext::TITANIA_FAQ, $this->id);
 
 		$message = $this->faq->generate_text_for_display();
 
 		// Grab attachments
 		$this->attachments
-			->configure(TITANIA_FAQ, $this->id)
+			->configure(ext::TITANIA_FAQ, $this->id)
 			->load();
 		$parsed_attachments = $this->attachments->parse_attachments($message);
 
@@ -454,7 +455,7 @@ class faq extends base
 			$this->db->sql_freeresult($result);
 
 			// Grab the tracking info
-			$this->tracking->get_tracks(TITANIA_FAQ, array_keys($items));
+			$this->tracking->get_tracks(ext::TITANIA_FAQ, array_keys($items));
 		}
 
 		return $items;
@@ -474,7 +475,7 @@ class faq extends base
 
 		// @todo probably should setup an edit time or something for better read tracking in case it was edited
 		$folder_img = $folder_alt = '';
-		$unread = $this->tracking->get_track(TITANIA_FAQ, $data['faq_id'], true) === 0;
+		$unread = $this->tracking->get_track(ext::TITANIA_FAQ, $data['faq_id'], true) === 0;
 		$this->display->topic_folder_img($folder_img, $folder_alt, 0, $unread);
 
 		$this->template->assign_block_vars('faqlist', array(

--- a/controller/contribution/manage.php
+++ b/controller/contribution/manage.php
@@ -16,6 +16,7 @@ namespace phpbb\titania\controller\contribution;
 use phpbb\exception\http_exception;
 use phpbb\titania\access;
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -266,7 +267,7 @@ class manage extends base
 
 			if ($this->ext_config->support_in_titania)
 			{
-				$this->subscriptions->subscribe(TITANIA_SUPPORT, $this->contrib->contrib_id, $new_author);
+				$this->subscriptions->subscribe(ext::TITANIA_SUPPORT, $this->contrib->contrib_id, $new_author);
 			}
 
 			redirect($this->contrib->get_url());
@@ -319,16 +320,16 @@ class manage extends base
 		$this->load_contrib($contrib_type, $contrib);
 		$this->is_moderator = $this->contrib->type->acl_get('moderate');
 		$this->use_colorizeit = strlen($this->ext_config->colorizeit) && $this->contrib->type->acl_get('colorizeit');
-		$this->can_edit_demo = $this->ext_config->can_modify_style_demo_url || $this->types->get(TITANIA_TYPE_STYLE)->acl_get('moderate')
-				|| $this->contrib->contrib_type != TITANIA_TYPE_STYLE;
+		$this->can_edit_demo = $this->ext_config->can_modify_style_demo_url || $this->types->get(ext::TITANIA_TYPE_STYLE)->acl_get('moderate')
+				|| $this->contrib->contrib_type != ext::TITANIA_TYPE_STYLE;
 
 		$this->status_list = array(
-			TITANIA_CONTRIB_NEW					=> 'CONTRIB_NEW',
-			TITANIA_CONTRIB_APPROVED			=> 'CONTRIB_APPROVED',
-			TITANIA_CONTRIB_DOWNLOAD_DISABLED	=> 'CONTRIB_DOWNLOAD_DISABLED',
-			TITANIA_CONTRIB_CLEANED				=> 'CONTRIB_CLEANED',
-			TITANIA_CONTRIB_HIDDEN				=> 'CONTRIB_HIDDEN',
-			TITANIA_CONTRIB_DISABLED			=> 'CONTRIB_DISABLED',
+			ext::TITANIA_CONTRIB_NEW				=> 'CONTRIB_NEW',
+			ext::TITANIA_CONTRIB_APPROVED			=> 'CONTRIB_APPROVED',
+			ext::TITANIA_CONTRIB_DOWNLOAD_DISABLED	=> 'CONTRIB_DOWNLOAD_DISABLED',
+			ext::TITANIA_CONTRIB_CLEANED			=> 'CONTRIB_CLEANED',
+			ext::TITANIA_CONTRIB_HIDDEN				=> 'CONTRIB_HIDDEN',
+			ext::TITANIA_CONTRIB_DISABLED			=> 'CONTRIB_DISABLED',
 		);
 	}
 
@@ -358,7 +359,7 @@ class manage extends base
 					$action_auth = false;
 			}
 		}
-		$is_author_editable = !in_array($this->contrib->contrib_status, array(TITANIA_CONTRIB_CLEANED, TITANIA_CONTRIB_DISABLED));
+		$is_author_editable = !in_array($this->contrib->contrib_status, array(ext::TITANIA_CONTRIB_CLEANED, ext::TITANIA_CONTRIB_DISABLED));
 
 		return $action_auth && ($this->is_moderator ||
 			($this->is_author && $is_author_editable && $this->auth->acl_get('u_titania_post_edit_own')));
@@ -372,7 +373,7 @@ class manage extends base
 	protected function load_screenshot()
 	{
 		$this->screenshots
-			->configure(TITANIA_SCREENSHOT, $this->contrib->contrib_id, true, 175, true)
+			->configure(ext::TITANIA_SCREENSHOT, $this->contrib->contrib_id, true, 175, true)
 			->get_operator()->load()
 		;
 		$this->screenshots->handle_form_action();
@@ -386,7 +387,7 @@ class manage extends base
 	protected function load_colorizeit()
 	{
 		$this->colorizeit_sample
-			->configure(TITANIA_CLR_SCREENSHOT, $this->contrib->contrib_id)
+			->configure(ext::TITANIA_CLR_SCREENSHOT, $this->contrib->contrib_id)
 			->get_operator()->load()
 		;
 		$this->colorizeit_sample->handle_form_action();
@@ -569,7 +570,7 @@ class manage extends base
 
 		foreach ($subscribe as $user_id)
 		{
-			$this->subscriptions->subscribe(TITANIA_SUPPORT, $this->contrib->contrib_id, $user_id);
+			$this->subscriptions->subscribe(ext::TITANIA_SUPPORT, $this->contrib->contrib_id, $user_id);
 		}
 	}
 
@@ -591,7 +592,7 @@ class manage extends base
 		}
 		$this->setup($contrib_type, $contrib);
 
-		if (!$this->is_moderator || $this->contrib->contrib_status != TITANIA_CONTRIB_APPROVED)
+		if (!$this->is_moderator || $this->contrib->contrib_status != ext::TITANIA_CONTRIB_APPROVED)
 		{
 			return $this->helper->needs_auth();
 		}
@@ -679,7 +680,7 @@ class manage extends base
 		$coauthors = $this->get_coauthor_usernames();
 
 		$this->template->assign_vars(array(
-			'S_CONTRIB_APPROVED'		=> $this->contrib->contrib_status == TITANIA_CONTRIB_APPROVED,
+			'S_CONTRIB_APPROVED'		=> $this->contrib->contrib_status == ext::TITANIA_CONTRIB_APPROVED,
 			'S_POST_ACTION'				=> $this->contrib->get_url('manage'),
 			'S_EDIT_SUBJECT'			=> $this->is_moderator || $this->contrib->is_author(),
 			'S_DELETE_CONTRIBUTION'		=> $this->check_auth('delete'),
@@ -773,16 +774,16 @@ class manage extends base
 
 		if ($name_change)
 		{
-			$this->contrib->report($name_change, false, TITANIA_ATTENTION_NAME_CHANGED);
+			$this->contrib->report($name_change, false, ext::TITANIA_ATTENTION_NAME_CHANGED);
 		}
 		if ($description_change)
 		{
-			$this->contrib->report($description_change, false, TITANIA_ATTENTION_DESC_CHANGED);
+			$this->contrib->report($description_change, false, ext::TITANIA_ATTENTION_DESC_CHANGED);
 		}
 
 		if ($category_change)
 		{
-			$this->contrib->report($category_change, false, TITANIA_ATTENTION_CATS_CHANGED);
+			$this->contrib->report($category_change, false, ext::TITANIA_ATTENTION_CATS_CHANGED);
 		}
 	}
 

--- a/controller/contribution/revision.php
+++ b/controller/contribution/revision.php
@@ -13,9 +13,9 @@
 
 namespace phpbb\titania\controller\contribution;
 
-use phpbb\titania\attachment\attachment;
 use phpbb\titania\composer\repository;
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class revision extends base
@@ -110,7 +110,7 @@ class revision extends base
 		}
 
 		// Only allow revisions that are still in the queue to be repacked.
-		if ($old_queue->queue_status < TITANIA_QUEUE_NEW || (!$old_queue->allow_author_repack && !$this->is_moderator))
+		if ($old_queue->queue_status < ext::TITANIA_QUEUE_NEW || (!$old_queue->allow_author_repack && !$this->is_moderator))
 		{
 			return $this->helper->needs_auth();
 		}
@@ -247,7 +247,7 @@ class revision extends base
 					);
 
 					$this->subscriptions->send_notifications(
-						TITANIA_QUEUE,
+						ext::TITANIA_QUEUE,
 						$this->contrib->contrib_type,
 						'subscribe_notify_forum',
 						$email_vars,
@@ -367,7 +367,7 @@ class revision extends base
 				if ($this->request->variable('subscribe_author', false))
 				{
 					$this->subscriptions->subscribe(
-						TITANIA_TOPIC,
+						ext::TITANIA_TOPIC,
 						$this->queue->queue_discussion_topic_id
 					);
 				}
@@ -398,11 +398,11 @@ class revision extends base
 		if (!$this->use_queue)
 		{
 			$this->revision->validation_date = time();
-			$this->revision->revision_status = TITANIA_REVISION_APPROVED;
+			$this->revision->revision_status = ext::TITANIA_REVISION_APPROVED;
 
-			if ($this->contrib->contrib_status != TITANIA_CONTRIB_APPROVED)
+			if ($this->contrib->contrib_status != ext::TITANIA_CONTRIB_APPROVED)
 			{
-				$this->contrib->change_status(TITANIA_CONTRIB_APPROVED);
+				$this->contrib->change_status(ext::TITANIA_CONTRIB_APPROVED);
 			}
 			repository::trigger_cron($this->config);
 		}
@@ -454,7 +454,7 @@ class revision extends base
 			$branch = (int) (is_array($version)) ? $version['phpbb_version_branch'] : $version;
 
 			if (in_array($branch, $this->repackable_branches) ||
-				(isset($in_queue[$branch]) && $in_queue[$branch]['queue_status'] == TITANIA_QUEUE_NEW))
+				(isset($in_queue[$branch]) && $in_queue[$branch]['queue_status'] == ext::TITANIA_QUEUE_NEW))
 			{
 				unset($in_queue[$branch]);
 			}
@@ -502,7 +502,7 @@ class revision extends base
 	protected function revision_branch_in_progress($branch)
 	{
 		return isset($this->revisions_in_queue[$branch])
-			&& ($this->revisions_in_queue[$branch]['queue_status'] > TITANIA_QUEUE_NEW
+			&& ($this->revisions_in_queue[$branch]['queue_status'] > ext::TITANIA_QUEUE_NEW
 				|| $this->revisions_in_queue[$branch]['queue_tested']
 			)
 		;
@@ -520,7 +520,7 @@ class revision extends base
 			'attachment_id'			=> ($this->attachment) ? $this->attachment->get_id() : 0,
 			'revision_name'			=> $settings['name'],
 			'revision_version'		=> $settings['version'],
-			'revision_status'		=> TITANIA_REVISION_NEW,
+			'revision_status'		=> ext::TITANIA_REVISION_NEW,
 			'queue_allow_repack'	=> $settings['allow_repack'],
 			'revision_license'		=> $settings['license'],
 		));
@@ -889,7 +889,7 @@ class revision extends base
 
 		$this->revision = new \titania_revision($this->contrib);
 		$this->uploader->configure(
-			TITANIA_CONTRIB,
+			ext::TITANIA_CONTRIB,
 			$this->contrib->contrib_id,
 			true
 		);
@@ -945,7 +945,7 @@ class revision extends base
 		$valid = false;
 
 		if ($attachment &&
-			$attachment->object_type == TITANIA_CONTRIB &&
+			$attachment->object_type == ext::TITANIA_CONTRIB &&
 			$attachment->object_id == $this->contrib->contrib_id &&
 			$attachment->get('is_orphan')
 		)
@@ -974,7 +974,7 @@ class revision extends base
 			{
 				// Is the author subscribed already?
 				return $this->subscriptions->is_subscribed(
-					TITANIA_TOPIC,
+					ext::TITANIA_TOPIC,
 					$this->queue->queue_discussion_topic_id
 				);
 			}
@@ -1047,7 +1047,7 @@ class revision extends base
 			'REVISION_LICENSE'			=> $this->request->variable('revision_license', $settings['license'], true),
 			'REVISION_CUSTOM_LICENSE'	=> $this->request->variable('revision_custom_license', $settings['custom_license'], true),
 			'REVISION_TEST_ACCOUNT'		=> $this->request->variable('revision_test_account', $settings['test_account'], true),
-			'REQUEST_TEST_ACCOUNT'		=> $this->use_queue && $this->contrib->type->id === TITANIA_TYPE_EXTENSION,
+			'REQUEST_TEST_ACCOUNT'		=> $this->use_queue && $this->contrib->type->id === ext::TITANIA_TYPE_EXTENSION,
 
 			'S_CUSTOM_LICENSE'			=> $this->has_custom_license($this->request->variable('revision_license', $settings['license'], true)),
 			'S_ALLOW_CUSTOM_LICENSE'	=> $this->contrib->type->license_allow_custom,

--- a/controller/contribution/revision_edit.php
+++ b/controller/contribution/revision_edit.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\controller\contribution;
 
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class revision_edit extends revision
@@ -77,7 +78,7 @@ class revision_edit extends revision
 		$this->handle_revision_delete();
 
 		// Translations
-		$this->translations->configure(TITANIA_TRANSLATION, $this->id, true);
+		$this->translations->configure(ext::TITANIA_TRANSLATION, $this->id, true);
 
 		if ($this->contrib->type->extra_upload)
 		{
@@ -144,7 +145,7 @@ class revision_edit extends revision
 	protected function load_attachment($id)
 	{
 		$this->attachment = $this->attachments
-			->configure(TITANIA_CONTRIB, $this->contrib->contrib_id)
+			->configure(ext::TITANIA_CONTRIB, $this->contrib->contrib_id)
 			->load(array((int) $id))
 			->get($id);
 
@@ -294,7 +295,7 @@ class revision_edit extends revision
 			;
 
 			// Update the status
-			if ($settings['status'] != $this->revision->revision_status && $settings['status'] != TITANIA_REVISION_APPROVED && $can_change_status)
+			if ($settings['status'] != $this->revision->revision_status && $settings['status'] != ext::TITANIA_REVISION_APPROVED && $can_change_status)
 			{
 				$this->revision->change_status($settings['status']);
 			}
@@ -357,13 +358,13 @@ class revision_edit extends revision
 		}
 
 		$status_list = array(
-			TITANIA_REVISION_NEW				=> 'REVISION_NEW',
-			TITANIA_REVISION_APPROVED			=> 'REVISION_APPROVED',
-			TITANIA_REVISION_DENIED				=> 'REVISION_DENIED',
-			TITANIA_REVISION_PULLED_SECURITY	=> 'REVISION_PULLED_FOR_SECURITY',
-			TITANIA_REVISION_PULLED_OTHER		=> 'REVISION_PULLED_FOR_OTHER',
-			TITANIA_REVISION_REPACKED			=> 'REVISION_REPACKED',
-			TITANIA_REVISION_RESUBMITTED		=> 'REVISION_RESUBMITTED',
+			ext::TITANIA_REVISION_NEW				=> 'REVISION_NEW',
+			ext::TITANIA_REVISION_APPROVED			=> 'REVISION_APPROVED',
+			ext::TITANIA_REVISION_DENIED			=> 'REVISION_DENIED',
+			ext::TITANIA_REVISION_PULLED_SECURITY	=> 'REVISION_PULLED_FOR_SECURITY',
+			ext::TITANIA_REVISION_PULLED_OTHER		=> 'REVISION_PULLED_FOR_OTHER',
+			ext::TITANIA_REVISION_REPACKED			=> 'REVISION_REPACKED',
+			ext::TITANIA_REVISION_RESUBMITTED		=> 'REVISION_RESUBMITTED',
 		);
 
 		// Display the status list

--- a/controller/contribution/support.php
+++ b/controller/contribution/support.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\controller\contribution;
 
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 
 class support extends base
 {
@@ -86,7 +87,7 @@ class support extends base
 				'contrib_type'	=> $this->contrib->type->url,
 				'contrib'		=> $this->contrib->contrib_name_clean,
 			),
-			TITANIA_SUPPORT,
+			ext::TITANIA_SUPPORT,
 			$this->helper->get_current_url()
 		);
 	}
@@ -115,7 +116,7 @@ class support extends base
 
 		// Subscriptions
 		$this->subscriptions->handle_subscriptions(
-			TITANIA_TOPIC,
+			ext::TITANIA_TOPIC,
 			$topic_id,
 			$this->topic->get_url(),
 			'SUBSCRIBE_TOPIC'
@@ -155,7 +156,7 @@ class support extends base
 
 		// Subscriptions
 		$this->subscriptions->handle_subscriptions(
-			TITANIA_SUPPORT,
+			ext::TITANIA_SUPPORT,
 			$this->contrib->contrib_id,
 			$this->contrib->get_url('support'),
 			'SUBSCRIBE_SUPPORT'
@@ -164,7 +165,7 @@ class support extends base
 		// Mark all topics read
 		if ($this->request->variable('mark', '') == 'topics')
 		{
-			$this->tracking->track(TITANIA_SUPPORT, $this->contrib->contrib_id);
+			$this->tracking->track(ext::TITANIA_SUPPORT, $this->contrib->contrib_id);
 		}
 
 		$can_post_topic = $this->ext_config->support_in_titania && $this->auth->acl_get('u_titania_topic');
@@ -182,7 +183,7 @@ class support extends base
 			'S_DISPLAY_SEARCHBOX'	=> true,
 			'S_SEARCHBOX_ACTION'	=> $this->helper->route('phpbb.titania.search.results'),
 			'SEARCH_HIDDEN_FIELDS'	=> build_hidden_fields(array(
-				'type'		=> TITANIA_SUPPORT,
+				'type'		=> ext::TITANIA_SUPPORT,
 				'contrib'	=> $this->contrib->contrib_id,
 			)),
 		));
@@ -230,7 +231,7 @@ class support extends base
 			$can_view_queue_discussion = $this->is_author || $this->contrib->type->acl_get('queue_discussion');
 
 			if ($this->topic->topic_access < $this->access->get_level() ||
-				($this->topic->topic_type == TITANIA_QUEUE_DISCUSSION && !$can_view_queue_discussion))
+				($this->topic->topic_type == ext::TITANIA_QUEUE_DISCUSSION && !$can_view_queue_discussion))
 			{
 				return false;
 			}

--- a/controller/download.php
+++ b/controller/download.php
@@ -15,6 +15,7 @@ namespace phpbb\titania\controller;
 
 use phpbb\titania\access;
 use phpbb\titania\entity\package;
+use phpbb\titania\ext;
 use Symfony\Component\Filesystem\Filesystem;
 
 class download
@@ -260,7 +261,7 @@ class download
 			$sql = 'SELECT attachment_id
 				FROM ' . TITANIA_REVISIONS_TABLE . '
 				WHERE contrib_id = ' . $contrib_id . '
-					AND revision_status = ' . TITANIA_REVISION_APPROVED . '
+					AND revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
 				ORDER BY revision_id DESC';
 			$this->db->sql_query_limit($sql, 1);
 			$download_id = (int) $this->db->sql_fetchfield('attachment_id');
@@ -280,7 +281,7 @@ class download
 		$status = self::OK;
 
 		// Don't allow downloads of revisions for TITANIA_CONTRIB_DOWNLOAD_DISABLED items unless on the team or an author.
-		if ($this->file['object_type'] == TITANIA_CONTRIB)
+		if ($this->file['object_type'] == ext::TITANIA_CONTRIB)
 		{
 			$status = $this->check_revision_auth();
 		}
@@ -288,7 +289,7 @@ class download
 		if ($status === self::OK)
 		{
 			// Only revisions can be downloaded as Composer packages
-			if ($this->type == 'composer' && $this->file['object_type'] != TITANIA_CONTRIB)
+			if ($this->type == 'composer' && $this->file['object_type'] != ext::TITANIA_CONTRIB)
 			{
 				return self::NOT_FOUND;
 			}
@@ -374,8 +375,8 @@ class download
 		$is_author = $contrib->is_author || $contrib->is_active_coauthor;
 		$can_download_hidden = $is_author || $contrib->type->acl_get('view') || $contrib->type->acl_get('moderate');
 		$use_queue = $this->ext_config->require_validation && $contrib->type->require_validation;
-		$is_unvalidated = $revision['revision_status'] != TITANIA_REVISION_APPROVED && $use_queue;
-		$is_disabled = $contrib->contrib_status == TITANIA_CONTRIB_DOWNLOAD_DISABLED;
+		$is_unvalidated = $revision['revision_status'] != ext::TITANIA_REVISION_APPROVED && $use_queue;
+		$is_disabled = $contrib->contrib_status == ext::TITANIA_CONTRIB_DOWNLOAD_DISABLED;
 
 		if (!$can_download_hidden && !$this->is_auto_validator() && ($is_unvalidated || $is_disabled))
 		{
@@ -403,7 +404,7 @@ class download
 
 		switch ((int) $this->file['object_type'])
 		{
-			case TITANIA_FAQ :
+			case ext::TITANIA_FAQ:
 				$sql = 'SELECT c.contrib_id, c.contrib_user_id
 					FROM ' . TITANIA_CONTRIB_FAQ_TABLE . ' f, ' .
 						TITANIA_CONTRIBS_TABLE . ' c
@@ -414,8 +415,8 @@ class download
 				$this->db->sql_freeresult($result);
 			break;
 
-			case TITANIA_SUPPORT :
-			case TITANIA_QUEUE_DISCUSSION :
+			case ext::TITANIA_SUPPORT:
+			case ext::TITANIA_QUEUE_DISCUSSION:
 				$sql = 'SELECT c.contrib_id, c.contrib_user_id
 					FROM ' . TITANIA_POSTS_TABLE . ' p, ' .
 						TITANIA_TOPICS_TABLE . ' t, ' .
@@ -472,7 +473,7 @@ class download
 		$this->db->sql_query($sql);
 
 		// Update download count for the contrib object as well
-		if ($this->file['object_type'] == TITANIA_CONTRIB)
+		if ($this->file['object_type'] == ext::TITANIA_CONTRIB)
 		{
 			$this->increase_contrib_download_count($this->file['object_id']);
 		}

--- a/controller/index.php
+++ b/controller/index.php
@@ -15,6 +15,7 @@ namespace phpbb\titania\controller;
 
 use phpbb\exception\http_exception;
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class index
@@ -129,7 +130,7 @@ class index
 		// Mark all contribs read
 		if ($this->request->variable('mark', '') == 'contribs')
 		{
-			$this->tracking->track(TITANIA_CONTRIB, self::ALL_CONTRIBS);
+			$this->tracking->track(ext::TITANIA_CONTRIB, self::ALL_CONTRIBS);
 		}
 
 		$this->template->assign_vars(array(

--- a/controller/manage/attention.php
+++ b/controller/manage/attention.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\controller\manage;
 
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 
 class attention extends base
 {
@@ -61,7 +62,7 @@ class attention extends base
 		// Display the current attention items
 		$options = array(
 			'attention_object_id'		=> $this->attention->attention_object_id,
-			'exclude_attention_types'	=> TITANIA_ATTENTION_UNAPPROVED,
+			'exclude_attention_types'	=> ext::TITANIA_ATTENTION_UNAPPROVED,
 		);
 		\attention_overlord::display_attention_list($options);
 
@@ -135,11 +136,11 @@ class attention extends base
 		switch ($type)
 		{
 			case 'reported' :
-				$type = TITANIA_ATTENTION_REPORTED;
+				$type = ext::TITANIA_ATTENTION_REPORTED;
 			break;
 
 			case 'unapproved' :
-				$type = TITANIA_ATTENTION_UNAPPROVED;
+				$type = ext::TITANIA_ATTENTION_UNAPPROVED;
 			break;
 
 			default :
@@ -162,7 +163,7 @@ class attention extends base
 
 		// Subscriptions
 		$this->subscriptions->handle_subscriptions(
-			TITANIA_ATTENTION,
+			ext::TITANIA_ATTENTION,
 			0,
 			$this->helper->route('phpbb.titania.manage.attention')
 		);
@@ -300,8 +301,8 @@ class attention extends base
 			$this->attention->delete();
 
 			$error = array(
-				TITANIA_POST	=> 'NO_POST',
-				TITANIA_CONTRIB	=> 'NO_CONTRIB',
+				ext::TITANIA_POST		=> 'NO_POST',
+				ext::TITANIA_CONTRIB	=> 'NO_CONTRIB',
 			);
 
 			throw new \Exception($error[$this->attention->attention_object_type]);

--- a/controller/manage/base.php
+++ b/controller/manage/base.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\controller\manage;
 
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 
 class base
 {
@@ -174,7 +175,7 @@ class base
 		$sql = 'SELECT COUNT(a.attention_id) AS cnt
 			FROM ' . TITANIA_ATTENTION_TABLE . ' a
 			LEFT JOIN ' . TITANIA_CONTRIBS_TABLE . ' c
-				ON (a.attention_object_type = ' . TITANIA_CONTRIB . '
+				ON (a.attention_object_type = ' . ext::TITANIA_CONTRIB . '
 					AND a.attention_object_id = c.contrib_id)
 			WHERE a.attention_close_time = 0
 				AND ' . \attention_overlord::get_permission_sql();

--- a/controller/manage/queue/item.php
+++ b/controller/manage/queue/item.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\controller\manage\queue;
 
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 
 class item extends \phpbb\titania\controller\manage\base
 {
@@ -280,7 +281,7 @@ class item extends \phpbb\titania\controller\manage\base
 			'manage/queue_post.html',
 			$this->id,
 			false,
-			TITANIA_QUEUE,
+			ext::TITANIA_QUEUE,
 			$this->helper->get_current_url()
 		);
 	}
@@ -293,7 +294,7 @@ class item extends \phpbb\titania\controller\manage\base
 	protected function allow_author_repack()
 	{
 		$topic = $this->queue->get_queue_discussion_topic();
-		$post = new \titania_post(TITANIA_QUEUE_DISCUSSION, $topic);
+		$post = new \titania_post(ext::TITANIA_QUEUE_DISCUSSION, $topic);
 		$post->__set_array(array(
 			'post_subject'		=> 'Re: ' . $post->topic->topic_subject,
 		));
@@ -345,7 +346,7 @@ class item extends \phpbb\titania\controller\manage\base
 	*/
 	protected function move()
 	{
-		$tags = $this->cache->get_tags(TITANIA_QUEUE);
+		$tags = $this->cache->get_tags(ext::TITANIA_QUEUE);
 
 		if (check_link_hash($this->request->variable('hash', ''), 'quick_actions') || confirm_box(true))
 		{

--- a/controller/manage/queue/queue.php
+++ b/controller/manage/queue/queue.php
@@ -13,7 +13,8 @@
 
 namespace phpbb\titania\controller\manage\queue;
 
-use \phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 
 class queue extends \phpbb\titania\controller\manage\base
 {
@@ -65,7 +66,7 @@ class queue extends \phpbb\titania\controller\manage\base
 		if (!$tag)
 		{
 			$this->subscriptions->handle_subscriptions(
-				TITANIA_QUEUE,
+				ext::TITANIA_QUEUE,
 				$this->type->id,
 				$this->helper->get_current_url(),
 				'SUBSCRIBE_QUEUE'
@@ -74,7 +75,7 @@ class queue extends \phpbb\titania\controller\manage\base
 		else
 		{
 			$this->subscriptions->handle_subscriptions(
-				TITANIA_QUEUE_TAG,
+				ext::TITANIA_QUEUE_TAG,
 				$tag,
 				$this->helper->get_current_url(),
 				'SUBSCRIBE_CATEGORY'

--- a/controller/manage/queue/tools.php
+++ b/controller/manage/queue/tools.php
@@ -13,6 +13,8 @@
 
 namespace phpbb\titania\controller\manage\queue;
 
+use phpbb\titania\ext;
+
 class tools
 {
 	/** @var \phpbb\user */
@@ -289,7 +291,7 @@ class tools
 	protected function load_attachment()
 	{
 		$this->attachments
-			->configure(TITANIA_CONTRIB, $this->contrib->contrib_id)
+			->configure(ext::TITANIA_CONTRIB, $this->contrib->contrib_id)
 			->load(array($this->revision->attachment_id))
 		;
 		$this->attachment = $this->attachments->get($this->revision->attachment_id);

--- a/controller/manage/queue_discussion.php
+++ b/controller/manage/queue_discussion.php
@@ -15,6 +15,7 @@ namespace phpbb\titania\controller\manage;
 
 use phpbb\titania\contribution\type\collection as type_collection;
 use phpbb\titania\contribution\type\type_interface;
+use phpbb\titania\ext;
 
 class queue_discussion extends base
 {
@@ -106,7 +107,7 @@ class queue_discussion extends base
 		// Mark all topics read
 		if ($this->request->variable('mark', '') == 'topics')
 		{
-			$this->tracking->track(TITANIA_QUEUE_DISCUSSION, self::ALL_TYPES);
+			$this->tracking->track(ext::TITANIA_QUEUE_DISCUSSION, self::ALL_TYPES);
 		}
 
 		$this->display->assign_global_vars();
@@ -137,7 +138,7 @@ class queue_discussion extends base
 
 		$sql = 'SELECT topic_category, COUNT(topic_id) AS cnt
 			FROM ' . TITANIA_TOPICS_TABLE . '
-			WHERE topic_type = ' . TITANIA_QUEUE_DISCUSSION . '
+			WHERE topic_type = ' . ext::TITANIA_QUEUE_DISCUSSION . '
 				AND ' . $this->db->sql_in_set('topic_category', $types) . '
 			GROUP BY topic_category';
 		$result = $this->db->sql_query($sql);

--- a/controller/queue_stats.php
+++ b/controller/queue_stats.php
@@ -15,6 +15,7 @@ namespace phpbb\titania\controller;
 
 use phpbb\titania\contribution\type\collection as type_collection;
 use phpbb\titania\date;
+use phpbb\titania\ext;
 
 class queue_stats
 {
@@ -130,8 +131,8 @@ class queue_stats
 	*/
 	protected function generate_stats()
 	{
-		$total_revs_denied		= $this->stats->get_queue_item_count(TITANIA_QUEUE_DENIED);
-		$total_revs_approved	= $this->stats->get_queue_item_count(TITANIA_QUEUE_APPROVED);
+		$total_revs_denied		= $this->stats->get_queue_item_count(ext::TITANIA_QUEUE_DENIED);
+		$total_revs_approved	= $this->stats->get_queue_item_count(ext::TITANIA_QUEUE_APPROVED);
 		$total_revs_validated	= $total_revs_denied + $total_revs_approved;
 
 		if (!$total_revs_validated)
@@ -144,8 +145,8 @@ class queue_stats
 		$year_ago->modify('-1 year')->setTimezone(new \DateTimezone('UTC'));
 
 		$validated_cache_ttl	= round($total_revs_validated / 1000) * 86400;
-		$validated_statuses		= array(TITANIA_QUEUE_DENIED, TITANIA_QUEUE_APPROVED);
-		$closed_statuses		= array(TITANIA_QUEUE_CLOSED, TITANIA_QUEUE_DENIED, TITANIA_QUEUE_APPROVED, TITANIA_QUEUE_HIDE);
+		$validated_statuses		= array(ext::TITANIA_QUEUE_DENIED, ext::TITANIA_QUEUE_APPROVED);
+		$closed_statuses		= array(ext::TITANIA_QUEUE_CLOSED, ext::TITANIA_QUEUE_DENIED, ext::TITANIA_QUEUE_APPROVED, ext::TITANIA_QUEUE_HIDE);
 
 		$oldest_unvalidated_rev	= $this->stats->get_oldest_revision_time(false, $closed_statuses);
 		$oldest_validated_rev	= $this->stats->get_oldest_revision_time($validated_statuses);

--- a/controller/search.php
+++ b/controller/search.php
@@ -16,6 +16,7 @@ namespace phpbb\titania\controller;
 use phpbb\exception\http_exception;
 use phpbb\titania\access;
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use phpbb\titania\user\helper as user_helper;
 
 class search
@@ -406,7 +407,7 @@ class search
 		{
 			$this->engine->where_in_set('phpbb_versions', $versions);
 		}
-		$this->engine->set_type(TITANIA_CONTRIB);
+		$this->engine->set_type(ext::TITANIA_CONTRIB);
 	}
 
 	/**
@@ -419,9 +420,9 @@ class search
 		$contrib_types = $this->types->get_ids();
 
 		$restrictions = array(
-			TITANIA_SUPPORT		=> $contrib_types,
-			TITANIA_CONTRIB		=> $contrib_types,
-			TITANIA_FAQ			=> $contrib_types,
+			ext::TITANIA_SUPPORT	=> $contrib_types,
+			ext::TITANIA_CONTRIB	=> $contrib_types,
+			ext::TITANIA_FAQ		=> $contrib_types,
 		);
 
 		// Enforce permissions on the results to ensure that we don't leak posts to users who don't have access to the originating queues.
@@ -430,12 +431,12 @@ class search
 
 		if (!empty($access_validation_queue))
 		{
-			$restrictions[TITANIA_QUEUE] = $access_validation_queue;
+			$restrictions[ext::TITANIA_QUEUE] = $access_validation_queue;
 		}
 
 		if (!empty($access_queue_discussion))
 		{
-			$restrictions[TITANIA_QUEUE_DISCUSSION] = $access_queue_discussion;
+			$restrictions[ext::TITANIA_QUEUE_DISCUSSION] = $access_queue_discussion;
 		}
 		$this->engine->set_granular_type_restrictions($restrictions);
 	}
@@ -473,13 +474,13 @@ class search
 
 		// Available Search Types
 		$this->search_types = array(
-			TITANIA_CONTRIB		=> 'CONTRIBUTION_NAME_DESCRIPTION',
-			TITANIA_FAQ			=> 'CONTRIB_FAQ',
+			ext::TITANIA_CONTRIB	=> 'CONTRIBUTION_NAME_DESCRIPTION',
+			ext::TITANIA_FAQ		=> 'CONTRIB_FAQ',
 		);
 
 		if ($this->ext_config->support_in_titania)
 		{
-			$this->search_types[TITANIA_SUPPORT] = 'CONTRIB_SUPPORT';
+			$this->search_types[ext::TITANIA_SUPPORT] = 'CONTRIB_SUPPORT';
 		}
 	}
 
@@ -522,20 +523,20 @@ class search
 
 		switch ($type)
 		{
-			case TITANIA_FAQ:
+			case ext::TITANIA_FAQ:
 				$controller = 'phpbb.titania.contrib.faq.item';
 			break;
 
-			case TITANIA_QUEUE:
+			case ext::TITANIA_QUEUE:
 				$controller = 'phpbb.titania.queue.item';
 			break;
 
-			case TITANIA_SUPPORT:
-			case TITANIA_QUEUE_DISCUSSION:
+			case ext::TITANIA_SUPPORT:
+			case ext::TITANIA_QUEUE_DISCUSSION:
 				$controller = 'phpbb.titania.contrib.support.topic';
 			break;
 
-			case TITANIA_CONTRIB:
+			case ext::TITANIA_CONTRIB:
 				$controller = 'phpbb.titania.contrib';
 			break;
 
@@ -595,17 +596,17 @@ class search
 		{
 			switch ($data['type'])
 			{
-				case TITANIA_CONTRIB :
+				case ext::TITANIA_CONTRIB:
 					$contribs[] = $data['id'];
 					break;
 
-				case TITANIA_SUPPORT :
-				case TITANIA_QUEUE_DISCUSSION :
-				case TITANIA_QUEUE :
+				case ext::TITANIA_SUPPORT:
+				case ext::TITANIA_QUEUE_DISCUSSION:
+				case ext::TITANIA_QUEUE :
 					$posts[] = $data['id'];
-				break;
+					break;
 
-				case TITANIA_FAQ :
+				case ext::TITANIA_FAQ:
 					$faqs[] = $data['id'];
 					break;
 			}
@@ -680,7 +681,7 @@ class search
 
 		while ($row = $this->db->sql_fetchrow($result))
 		{
-			$id = TITANIA_CONTRIB . '_' . $row['id'];
+			$id = ext::TITANIA_CONTRIB . '_' . $row['id'];
 			$row['url'] = serialize(array(
 				'contrib_type'	=> $this->types->get($row['contrib_type'])->url,
 				'contrib'		=> $row['contrib_name_clean'],
@@ -717,7 +718,7 @@ class search
 
 		while ($row = $this->db->sql_fetchrow($result))
 		{
-			$id = TITANIA_FAQ . '_' . $row['id'];
+			$id = ext::TITANIA_FAQ . '_' . $row['id'];
 			$row['url'] = serialize(array(
 				'contrib_type'	=> $this->types->get($row['contrib_type'])->url,
 				'contrib'		=> $row['contrib_name_clean'],

--- a/controller/support.php
+++ b/controller/support.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\controller;
 
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 
 class support
 {
@@ -82,7 +83,7 @@ class support
 			// Mark all topics read
 			if ($this->request->variable('mark', '') == 'topics')
 			{
-				$this->tracking->track(TITANIA_ALL_SUPPORT, self::ALL_SUPPORT);
+				$this->tracking->track(ext::TITANIA_ALL_SUPPORT, self::ALL_SUPPORT);
 			}
 
 			// Mark all topics read

--- a/controller/ucp/subscriptions.php
+++ b/controller/ucp/subscriptions.php
@@ -15,6 +15,7 @@ namespace phpbb\titania\controller\ucp;
 
 use phpbb\titania\access;
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 
 class subscriptions
 {
@@ -148,19 +149,19 @@ class subscriptions
 	protected function display_sections()
 	{
 		$object_types = array(
-			TITANIA_SUPPORT,
-			TITANIA_QUEUE,
-			TITANIA_ATTENTION
+			ext::TITANIA_SUPPORT,
+			ext::TITANIA_QUEUE,
+			ext::TITANIA_ATTENTION
 		);
 		$cases = array(
-			TITANIA_SUPPORT		=> 'c.contrib_last_update',
+			ext::TITANIA_SUPPORT		=> 'c.contrib_last_update',
 		);
 
 		$user_ids = $rows = array();
 		$subscription_count = $this->get_subscription_count($object_types);
 		$this->build_sort($subscription_count);
 
-		$sql_ary = $this->get_subscription_sql_ary($cases, $object_types, TITANIA_SUPPORT);
+		$sql_ary = $this->get_subscription_sql_ary($cases, $object_types, ext::TITANIA_SUPPORT);
 		$sql = $this->db->sql_build_query('SELECT', $sql_ary);
 		$result = $this->db->sql_query_limit($sql, $this->sort->limit, $this->sort->start);
 
@@ -178,7 +179,7 @@ class subscriptions
 		{
 			switch ($row['watch_object_type'])
 			{
-				case TITANIA_SUPPORT:
+				case ext::TITANIA_SUPPORT:
 					// Contribution no longer exists.
 					if (!$row['contrib_id'])
 					{
@@ -188,11 +189,11 @@ class subscriptions
 					$vars = $this->get_support_tpl_row($row);
 				break;
 
-				case TITANIA_ATTENTION:
+				case ext::TITANIA_ATTENTION:
 					$vars = $vars = $this->get_attention_tpl_row($row);
 				break;
 
-				case TITANIA_QUEUE:
+				case ext::TITANIA_QUEUE:
 					$vars = $this->get_queue_tpl_row($row);
 				break;
 
@@ -211,31 +212,31 @@ class subscriptions
 	*/
 	protected function display_items()
 	{
-		$object_types = array(TITANIA_CONTRIB, TITANIA_TOPIC);
+		$object_types = array(ext::TITANIA_CONTRIB, ext::TITANIA_TOPIC);
 
 		$subscription_count = $this->get_subscription_count($object_types);
 		$this->build_sort($subscription_count);
 
 		$cases = array(
-			TITANIA_CONTRIB	=> 'c.contrib_last_update',
-			TITANIA_TOPIC	=> 't.topic_last_post_time',
+			ext::TITANIA_CONTRIB	=> 'c.contrib_last_update',
+			ext::TITANIA_TOPIC		=> 't.topic_last_post_time',
 		);
-		$sql_ary = $this->get_subscription_sql_ary($cases, $object_types, TITANIA_CONTRIB);
+		$sql_ary = $this->get_subscription_sql_ary($cases, $object_types, ext::TITANIA_CONTRIB);
 
 		$sql_ary['LEFT_JOIN'][] = array(
 			'FROM'	=> array($this->topics_table => 't'),
-			'ON'	=> 'w.watch_object_type = ' . TITANIA_TOPIC. '
+			'ON'	=> 'w.watch_object_type = ' . ext::TITANIA_TOPIC. '
 							AND t.topic_id = w.watch_object_id',
 		);
 
 		// Additional tracking for support topics
-		$this->tracking->get_track_sql($sql_ary, TITANIA_TOPIC, 't.topic_id');
-		$this->tracking->get_track_sql($sql_ary, TITANIA_SUPPORT, 0, 'tsa');
-		$this->tracking->get_track_sql($sql_ary, TITANIA_SUPPORT, 't.parent_id', 'tsc');
-		$this->tracking->get_track_sql($sql_ary, TITANIA_QUEUE_DISCUSSION, 0, 'tqt');
+		$this->tracking->get_track_sql($sql_ary, ext::TITANIA_TOPIC, 't.topic_id');
+		$this->tracking->get_track_sql($sql_ary, ext::TITANIA_SUPPORT, 0, 'tsa');
+		$this->tracking->get_track_sql($sql_ary, ext::TITANIA_SUPPORT, 't.parent_id', 'tsc');
+		$this->tracking->get_track_sql($sql_ary, ext::TITANIA_QUEUE_DISCUSSION, 0, 'tqt');
 
 		// Tracking for contributions
-		$this->tracking->get_track_sql($sql_ary, TITANIA_CONTRIB, 'c.contrib_id', 'tc');
+		$this->tracking->get_track_sql($sql_ary, ext::TITANIA_CONTRIB, 'c.contrib_id', 'tc');
 
 		$sql = $this->db->sql_build_query('SELECT', $sql_ary);
 		$result = $this->db->sql_query_limit($sql, $this->sort->limit, $this->sort->start);
@@ -246,7 +247,7 @@ class subscriptions
 			$this->tracking->store_from_db($row);
 			$rows[] = $row;
 
-			if ($row['watch_object_type'] == TITANIA_TOPIC)
+			if ($row['watch_object_type'] == ext::TITANIA_TOPIC)
 			{
 				$user_ids[] = (int) $row['topic_first_post_user_id'];
 				$user_ids[] = (int) $row['topic_last_post_user_id'];
@@ -263,7 +264,7 @@ class subscriptions
 
 		foreach ($rows as $row)
 		{
-			if ($row['watch_object_type'] == TITANIA_TOPIC)
+			if ($row['watch_object_type'] == ext::TITANIA_TOPIC)
 			{
 				// Topic was deleted, remove all subscriptions for it.
 				if (!$row['topic_id'])
@@ -404,7 +405,7 @@ class subscriptions
 			$folder_img,
 			$folder_alt,
 			0,
-			$this->tracking->is_unread(TITANIA_CONTRIB, $contrib->contrib_id, $contrib->contrib_last_update)
+			$this->tracking->is_unread(ext::TITANIA_CONTRIB, $contrib->contrib_id, $contrib->contrib_last_update)
 		);
 
 		return array(
@@ -437,15 +438,15 @@ class subscriptions
 		$topic->__set_array($row);
 		$additional_unread_fields = array(
 			array(
-				'type'			=> TITANIA_SUPPORT,
+				'type'			=> ext::TITANIA_SUPPORT,
 				'id'			=> 0,
 			),
 			array(
-				'type'			=> TITANIA_SUPPORT,
+				'type'			=> ext::TITANIA_SUPPORT,
 				'parent_match'	=> true,
 			),
 			array(
-				'type' 			=> TITANIA_QUEUE_DISCUSSION,
+				'type' 			=> ext::TITANIA_QUEUE_DISCUSSION,
 				'id'			=> 0,
 				'type_match'	=> true,
 			),
@@ -457,9 +458,9 @@ class subscriptions
 
 		$subscription_target = '';
 		$type_lang = array(
-			TITANIA_QUEUE_DISCUSSION	=> 'SUBSCRIPTION_QUEUE_VALIDATION',
-			TITANIA_QUEUE				=> 'SUBSCRIPTION_QUEUE',
-			TITANIA_SUPPORT				=> 'SUBSCRIPTION_SUPPORT_TOPIC',
+			ext::TITANIA_QUEUE_DISCUSSION	=> 'SUBSCRIPTION_QUEUE_VALIDATION',
+			ext::TITANIA_QUEUE				=> 'SUBSCRIPTION_QUEUE',
+			ext::TITANIA_SUPPORT			=> 'SUBSCRIPTION_SUPPORT_TOPIC',
 		);
 
 		if (isset($type_lang[$row['topic_type']]))
@@ -468,7 +469,7 @@ class subscriptions
 		}
 
 		// Tracking check
-		$last_read_mark = $this->tracking->get_track(TITANIA_TOPIC, $topic->topic_id, true);
+		$last_read_mark = $this->tracking->get_track(ext::TITANIA_TOPIC, $topic->topic_id, true);
 		$last_read_mark = max($last_read_mark, $this->tracking->find_last_read_mark(
 			$topic->additional_unread_fields,
 			$topic->topic_type,
@@ -497,7 +498,7 @@ class subscriptions
 				'#'		=> 'p' . $topic->topic_last_post_id,
 			))),
 
-			'S_ACCESS_TEAMS'				=> $row['topic_access'] == access::TEAM_LEVEL || $row['topic_type'] == TITANIA_QUEUE,
+			'S_ACCESS_TEAMS'				=> $row['topic_access'] == access::TEAM_LEVEL || $row['topic_type'] == ext::TITANIA_QUEUE,
 			'S_ACCESS_AUTHORS'				=> $row['topic_access'] == access::AUTHOR_LEVEL,
 			'S_TOPIC'						=> true,
 		);

--- a/cron/task/cleanup.php
+++ b/cron/task/cleanup.php
@@ -13,6 +13,8 @@
 
 namespace phpbb\titania\cron\task;
 
+use phpbb\titania\ext;
+
 class cleanup extends \phpbb\cron\task\base
 {
 	/** @var \phpbb\db\driver\driver_interface */
@@ -162,7 +164,7 @@ class cleanup extends \phpbb\cron\task\base
 		}
 
 		return $this->get_attachments(
-			'object_type = ' . TITANIA_CONTRIB . '
+			'object_type = ' . ext::TITANIA_CONTRIB . '
 				AND ' . $this->db->sql_in_set('attachment_id', $ids)
 		);
 	}
@@ -177,7 +179,7 @@ class cleanup extends \phpbb\cron\task\base
 		$time_limit = time() - (3600 * 4);
 
 		return $this->get_attachments(
-			'object_type <> ' . TITANIA_CONTRIB . '
+			'object_type <> ' . ext::TITANIA_CONTRIB . '
 				AND is_orphan = 1 AND filetime < ' . $time_limit
 		);
 	}

--- a/entity/package.php
+++ b/entity/package.php
@@ -13,9 +13,9 @@
 
 namespace phpbb\titania\entity;
 
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Expression\Expression;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Filesystem\Filesystem;
 
 class package
 {

--- a/ext.php
+++ b/ext.php
@@ -15,14 +15,4 @@ namespace phpbb\titania;
 
 class ext extends \phpbb\extension\base
 {
-	public function is_enableable()
-	{
-		if (!defined('TITANIA_SUPPORT'))
-		{
-			$php_ext = $this->container->getParameter('core.php_ext');
-			include($this->extension_path . 'includes/constants.' . $php_ext);
-		}
-
-		return true;
-	}
 }

--- a/ext.php
+++ b/ext.php
@@ -15,4 +15,81 @@ namespace phpbb\titania;
 
 class ext extends \phpbb\extension\base
 {
+	// Contribution types
+	const TITANIA_TYPE_MOD = 1;
+	const TITANIA_TYPE_STYLE = 2;
+	const TITANIA_TYPE_CONVERTER = 3;
+	const TITANIA_TYPE_OFFICIAL_TOOL = 4;
+	const TITANIA_TYPE_BRIDGE = 5;
+	const TITANIA_TYPE_TRANSLATION = 6;
+	const TITANIA_TYPE_BBCODE = 7;
+	const TITANIA_TYPE_EXTENSION = 8;
+
+	// Category option flags
+	const TITANIA_CAT_FLAG_DEMO = 1; // Integrated styles demo
+	const TITANIA_CAT_FLAG_ALL_VERSIONS = 2; // Contributions support all phpBB versions
+
+	// Contrib status
+	const TITANIA_CONTRIB_NEW = 1; // Does not have any validated revisions; Hidden from category listing, shown if directly linked to
+	const TITANIA_CONTRIB_APPROVED = 2; // Has at least one validated revision
+	const TITANIA_CONTRIB_CLEANED = 3; // "Cleaned" contributions, such as those for really old versions of phpBB and no longer supported by anyone; Hidden from category listing, shown if directly linked to, not editable by authors
+	const TITANIA_CONTRIB_DOWNLOAD_DISABLED = 4; // Downloads disabled (while under review for security audit or some similar reason); Shown the same as Approved, but with downloads disabled for non-team/author
+	const TITANIA_CONTRIB_HIDDEN = 5; // Hidden from category listing, shown to author/teams if directly linked to
+	const TITANIA_CONTRIB_DISABLED = 6; // Hidden from category listing, shown to author/teams if directly linked to, not editable by authors
+
+	// Revision status
+	const TITANIA_REVISION_NEW = 1; // Is not approved yet
+	const TITANIA_REVISION_APPROVED = 2; // Is approved (this is the only status shown to the public unless approval is not required)
+	const TITANIA_REVISION_DENIED = 3; // Is denied
+	const TITANIA_REVISION_PULLED_SECURITY = 4; // Has been pulled for a security vulnerability
+	const TITANIA_REVISION_PULLED_OTHER = 5; // Has been pulled for an other non-security reason
+	const TITANIA_REVISION_REPACKED = 6; // Has been repacked
+	const TITANIA_REVISION_RESUBMITTED = 7; // Has been resubmitted
+	const TITANIA_REVISION_ON_HOLD = 8; // Aimed for next phpBB release
+
+	// Queue status
+	const TITANIA_QUEUE_CLOSED = -3; // Special case to hide closed revisions from the queue
+	const TITANIA_QUEUE_DENIED = -2; // Special case to hide denied revisions from the queue
+	const TITANIA_QUEUE_APPROVED = -1; // Special case to hide approved revisions from the queue
+	const TITANIA_QUEUE_HIDE = 0; // Special case to hide an unfinished submission
+	const TITANIA_QUEUE_NEW = 1; // Same as QUEUE_NEW in the Tag Fields table
+
+	// Main TYPE constants (use whenever possible)
+	const TITANIA_CONTRIB = 1;
+	const TITANIA_FAQ = 2;
+	const TITANIA_QUEUE = 3;
+	const TITANIA_SUPPORT = 4;
+	const TITANIA_TRACKER = 5;
+	const TITANIA_TOPIC = 6;
+	const TITANIA_AUTHOR = 7;
+	const TITANIA_CATEGORY = 8;
+	const TITANIA_QUEUE_DISCUSSION = 9;
+	const TITANIA_POST = 10;
+	const TITANIA_SCREENSHOT = 11;
+	const TITANIA_ATTENTION = 12;
+	const TITANIA_TRANSLATION = 13;
+	const TITANIA_CLR_SCREENSHOT = 14; // ColorizeIt sample image
+	const TITANIA_ALL_SUPPORT = 15;
+	const TITANIA_QUEUE_TAG = 16;
+
+	// Errorbox types
+	const TITANIA_ERROR = 1;
+	const TITANIA_SUCCESS = 2;
+	const TITANIA_DEBUG = 3;
+
+	// Author constants
+	const TITANIA_AUTHOR_HIDDEN = 0;
+	const TITANIA_AUTHOR_VISIBLE = 1;
+
+	// Access Levels
+	const TITANIA_ACCESS_TEAMS = 0;
+	const TITANIA_ACCESS_AUTHORS = 1;
+	const TITANIA_ACCESS_PUBLIC = 2;
+
+	// Attention stuff
+	const TITANIA_ATTENTION_REPORTED = 1;
+	const TITANIA_ATTENTION_UNAPPROVED = 2;
+	const TITANIA_ATTENTION_CATS_CHANGED = 3;
+	const TITANIA_ATTENTION_DESC_CHANGED = 4;
+	const TITANIA_ATTENTION_NAME_CHANGED = 5;
 }

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -11,6 +11,13 @@
 *
 */
 
+/**
+ * All constants defined below are deprecated and may be removed in the future.
+ * Use the class constants as defined in ext.php instead.
+ *
+ * @deprecated
+ */
+
 // Contribution types
 define('TITANIA_TYPE_MOD', 1);
 define('TITANIA_TYPE_STYLE', 2);

--- a/includes/hooks/_hook_phpbb.com.php
+++ b/includes/hooks/_hook_phpbb.com.php
@@ -19,6 +19,7 @@ if (!defined('IN_PHPBB'))
 	exit;
 }
 
+use phpbb\titania\ext;
 use phpbb\titania\message\message;
 
 //define('TEST_INSTALLATION', true);
@@ -40,7 +41,7 @@ titania::$hook->register_ary('phpbb_com_', array(
 // Display a warning for styles not meeting the licensing guidelines
 function phpbb_com_titania_contribution_assign_details($hook, &$vars, $contrib)
 {
-	if ($contrib->contrib_type != TITANIA_TYPE_STYLE || empty($contrib->download))
+	if ($contrib->contrib_type != ext::TITANIA_TYPE_STYLE || empty($contrib->download))
 	{
 		return;
 	}
@@ -70,7 +71,7 @@ function phpbb_com_titania_contribution_assign_details($hook, &$vars, $contrib)
 */
 function phpbb_com_titania_queue_update_first_queue_post($hook, &$post_object, $queue_object)
 {
-	if ($queue_object->queue_status == TITANIA_QUEUE_HIDE || !$queue_object->queue_topic_id)
+	if ($queue_object->queue_status == ext::TITANIA_QUEUE_HIDE || !$queue_object->queue_topic_id)
 	{
 		return;
 	}
@@ -80,7 +81,7 @@ function phpbb_com_titania_queue_update_first_queue_post($hook, &$post_object, $
 	// First we copy over the queue discussion topic if required
 	$sql = 'SELECT topic_id, phpbb_topic_id, topic_category FROM ' . TITANIA_TOPICS_TABLE . '
 		WHERE parent_id = ' . $queue_object->contrib_id . '
-			AND topic_type = ' . TITANIA_QUEUE_DISCUSSION;
+			AND topic_type = ' . ext::TITANIA_QUEUE_DISCUSSION;
 	$result = phpbb::$db->sql_query($sql);
 	$topic_row = phpbb::$db->sql_fetchrow($result);
 	phpbb::$db->sql_freeresult($result);
@@ -88,7 +89,7 @@ function phpbb_com_titania_queue_update_first_queue_post($hook, &$post_object, $
 	// Do we need to create the queue discussion topic or not?
 	if ($topic_row['topic_id'] && !$topic_row['phpbb_topic_id'])
 	{
-		$forum_id = phpbb_com_forum_id($post_object->topic->topic_category, TITANIA_QUEUE_DISCUSSION);
+		$forum_id = phpbb_com_forum_id($post_object->topic->topic_category, ext::TITANIA_QUEUE_DISCUSSION);
 
 		$temp_post = new titania_post;
 
@@ -128,15 +129,15 @@ function phpbb_com_titania_queue_update_first_queue_post($hook, &$post_object, $
 			{
 				switch ($topic_row['topic_category'])
 				{
-					case TITANIA_TYPE_EXTENSION :
+					case ext::TITANIA_TYPE_EXTENSION:
 						$options['poster_id'] = titania::$config->forum_extension_robot;
 					break;
 
-					case TITANIA_TYPE_MOD :
+					case ext::TITANIA_TYPE_MOD:
 						$options['poster_id'] = titania::$config->forum_mod_robot;
 					break;
 
-					case TITANIA_TYPE_STYLE :
+					case ext::TITANIA_TYPE_STYLE:
 						$options['poster_id'] = titania::$config->forum_style_robot;
 					break;
 				}
@@ -188,22 +189,22 @@ function phpbb_com_titania_queue_update_first_queue_post($hook, &$post_object, $
 
 	switch ($post_object->topic->topic_category)
 	{
-		case TITANIA_TYPE_EXTENSION :
+		case ext::TITANIA_TYPE_EXTENSION:
 			$post_object->topic->topic_first_post_user_id = titania::$config->forum_extension_robot;
 			$lang_var = 'EXTENSION_QUEUE_TOPIC';
 		break;
 
-		case TITANIA_TYPE_MOD :
+		case ext::TITANIA_TYPE_MOD:
 			$post_object->topic->topic_first_post_user_id = titania::$config->forum_mod_robot;
 			$lang_var = 'MOD_QUEUE_TOPIC';
 		break;
 
-		case TITANIA_TYPE_STYLE :
+		case ext::TITANIA_TYPE_STYLE:
 			$post_object->topic->topic_first_post_user_id = titania::$config->forum_style_robot;
 			$lang_var = 'STYLE_QUEUE_TOPIC';
 		break;
 
-		default :
+		default:
 			return;
 		break;
 	}
@@ -327,9 +328,9 @@ function phpbb_com_titania_post_hard_delete($hook, &$post_object)
 	{
 		return;
 	}
-	
+
 	phpbb::_include('functions_posting', 'delete_post');
-	
+
 	$sql = 'SELECT t.*, p.*
 	FROM ' . TOPICS_TABLE . ' t, ' . POSTS_TABLE . ' p
 		WHERE p.post_id = ' . $post_object->phpbb_post_id . '
@@ -406,52 +407,52 @@ function phpbb_com_forum_id($type, $mode)
 
 	switch ($type)
 	{
-		case TITANIA_TYPE_EXTENSION :
+		case ext::TITANIA_TYPE_EXTENSION:
 			switch ($mode)
 			{
-				case TITANIA_QUEUE_DISCUSSION :
+				case ext::TITANIA_QUEUE_DISCUSSION:
 					return 516;
 				break;
 
-				case TITANIA_QUEUE :
+				case ext::TITANIA_QUEUE:
 					return 511;
 				break;
 
-				case 'trash' :
+				case 'trash':
 					return 521;
 				break;
 			}
 		break;
 
-		case TITANIA_TYPE_MOD :
+		case ext::TITANIA_TYPE_MOD:
 			switch ($mode)
 			{
-				case TITANIA_QUEUE_DISCUSSION :
+				case ext::TITANIA_QUEUE_DISCUSSION:
 					return 61;
 				break;
 
-				case TITANIA_QUEUE :
+				case ext::TITANIA_QUEUE:
 					return 38;
 				break;
 
-				case 'trash' :
+				case 'trash':
 					return 28;
 				break;
 			}
 		break;
 
-		case TITANIA_TYPE_STYLE :
+		case ext::TITANIA_TYPE_STYLE:
 			switch ($mode)
 			{
-				case TITANIA_QUEUE_DISCUSSION :
+				case ext::TITANIA_QUEUE_DISCUSSION:
 					return 87;
 				break;
 
-				case TITANIA_QUEUE :
+				case ext::TITANIA_QUEUE:
 					return 40;
 				break;
 
-				case 'trash' :
+				case 'trash':
 					return 83;
 				break;
 			}

--- a/includes/objects/attention.php
+++ b/includes/objects/attention.php
@@ -11,6 +11,8 @@
 *
 */
 
+use phpbb\titania\ext;
+
 /**
  * Class to abstract attention items
  * @package Titania
@@ -101,7 +103,7 @@ class titania_attention extends \phpbb\titania\entity\database_base
 				'U_VIEW'	=> $this->path_helper->strip_url_params($u_view, 'sid'),
 			);
 			$this->subscriptions->send_notifications(
-				TITANIA_ATTENTION,
+				ext::TITANIA_ATTENTION,
 				0,
 				'subscribe_notify',
 				$email_vars,
@@ -177,7 +179,7 @@ class titania_attention extends \phpbb\titania\entity\database_base
 	public function is_report()
 	{
 		return !in_array($this->attention_type, array(
-			TITANIA_ATTENTION_UNAPPROVED,
+			ext::TITANIA_ATTENTION_UNAPPROVED,
 		));
 	}
 

--- a/includes/objects/attention_types/contribution.php
+++ b/includes/objects/attention_types/contribution.php
@@ -11,6 +11,8 @@
 *
 */
 
+use phpbb\titania\ext;
+
 class titania_attention_contribution extends titania_attention
 {
 	/** @var \phpbb\user */
@@ -74,25 +76,25 @@ class titania_attention_contribution extends titania_attention
 
 		switch ((int) $this->attention_type)
 		{
-			case TITANIA_ATTENTION_REPORTED :
+			case ext::TITANIA_ATTENTION_REPORTED :
 				$labels = array_merge($labels, array(
 					'reason' => 'REPORTED',
 				));
 			break;
 
-			case TITANIA_ATTENTION_CATS_CHANGED :
+			case ext::TITANIA_ATTENTION_CATS_CHANGED :
 				$labels = array_merge($labels, array(
 					'reason' => 'ATTENTION_CONTRIB_CATEGORIES_CHANGED',
 				));
 			break;
 
-			case TITANIA_ATTENTION_NAME_CHANGED :
+			case ext::TITANIA_ATTENTION_NAME_CHANGED :
 				$labels = array_merge($labels, array(
 					'reason' => 'ATTENTION_CONTRIB_NAME_CHANGED',
 				));
 			break;
 
-			case TITANIA_ATTENTION_DESC_CHANGED :
+			case ext::TITANIA_ATTENTION_DESC_CHANGED :
 				$labels = array_merge($labels, array(
 					'reason' => 'ATTENTION_CONTRIB_DESC_CHANGED',
 				));

--- a/includes/objects/attention_types/post.php
+++ b/includes/objects/attention_types/post.php
@@ -11,6 +11,8 @@
 *
 */
 
+use phpbb\titania\ext;
+
 class titania_attention_post extends titania_attention
 {
 	/** @var \phpbb\titania\subscriptions */
@@ -91,7 +93,7 @@ class titania_attention_post extends titania_attention
 
 		switch ((int) $this->attention_type)
 		{
-			case TITANIA_ATTENTION_REPORTED :
+			case ext::TITANIA_ATTENTION_REPORTED :
 				$labels = array_merge($labels, array(
 					'reason'	=> 'REPORTED',
 					'closed'	=> 'CLOSED',
@@ -99,7 +101,7 @@ class titania_attention_post extends titania_attention
 				));
 			break;
 
-			case TITANIA_ATTENTION_UNAPPROVED :
+			case ext::TITANIA_ATTENTION_UNAPPROVED :
 				$labels = array_merge($labels, array(
 					'reason'	=> 'NEW_UNAPPROVED_POST',
 					'closed'	=> 'APPROVED',
@@ -125,7 +127,7 @@ class titania_attention_post extends titania_attention
 		// Check for any open reports.
 		$sql = 'SELECT COUNT(attention_id) AS cnt FROM ' . TITANIA_ATTENTION_TABLE . '
 			WHERE attention_object_id = ' . (int) $this->post->post_id . '
-				AND attention_object_type = ' . TITANIA_POST . '
+				AND attention_object_type = ' . ext::TITANIA_POST . '
 				AND attention_close_time = 0';
 		phpbb::$db->sql_query($sql);
 		$open_reports = phpbb::$db->sql_fetchfield('cnt');
@@ -271,7 +273,7 @@ class titania_attention_post extends titania_attention
 			$message_vars = array(
 				'U_VIEW' => $this->path_helper->strip_url_params($u_view, 'sid'),
 			);
-			$object_type = array(TITANIA_TOPIC, TITANIA_SUPPORT);
+			$object_type = array(ext::TITANIA_TOPIC, ext::TITANIA_SUPPORT);
 			$object_id = array($this->post->topic_id, $this->post->topic->parent_id);
 
 			$this->send_notifications($object_type, $object_id, 'subscribe_notify_contrib', $message_vars);

--- a/includes/objects/author.php
+++ b/includes/objects/author.php
@@ -11,6 +11,8 @@
 *
 */
 
+use phpbb\titania\ext;
+
 /**
 * Class to abstract titania authors.
 * @package Titania
@@ -36,7 +38,7 @@ class titania_author extends \phpbb\titania\entity\message_base
 	 *
 	 * @var string
 	 */
-	protected $object_type = TITANIA_AUTHOR;
+	protected $object_type = ext::TITANIA_AUTHOR;
 
 	/**
 	 * Rating of this author
@@ -326,7 +328,7 @@ class titania_author extends \phpbb\titania\entity\message_base
 			if (!isset($type->author_count))
 			{
 				// Figure out the counts some other way
-				$valid_statuses = array(TITANIA_CONTRIB_APPROVED, TITANIA_CONTRIB_DOWNLOAD_DISABLED);
+				$valid_statuses = array(ext::TITANIA_CONTRIB_APPROVED, ext::TITANIA_CONTRIB_DOWNLOAD_DISABLED);
 
 				$sql_ary = array(
 					'SELECT'	=> 'COUNT(*) AS contrib_cnt',

--- a/includes/objects/category.php
+++ b/includes/objects/category.php
@@ -11,6 +11,7 @@
 *
 */
 
+use phpbb\titania\ext;
 use phpbb\titania\sync;
 
 /**
@@ -38,7 +39,7 @@ class titania_category extends \phpbb\titania\entity\message_base
 	 *
 	 * @var string
 	 */
-	protected $object_type = TITANIA_CATEGORY;
+	protected $object_type = ext::TITANIA_CATEGORY;
 
 	/** @var \phpbb\titania\controller\helper */
 	protected $controller_helper;

--- a/includes/objects/faq.php
+++ b/includes/objects/faq.php
@@ -12,6 +12,7 @@
 */
 
 use phpbb\titania\count;
+use phpbb\titania\ext;
 use phpbb\titania\message\message;
 
 /**
@@ -39,7 +40,7 @@ class titania_faq extends \phpbb\titania\entity\message_base
 	 *
 	 * @var string
 	 */
-	protected $object_type = TITANIA_FAQ;
+	protected $object_type = ext::TITANIA_FAQ;
 
 	/** @param \titania_contribution */
 	public $contrib;
@@ -194,7 +195,7 @@ class titania_faq extends \phpbb\titania\entity\message_base
 		parent::submit();
 
 		// Index
-		$this->search_manager->index(TITANIA_FAQ, $this->faq_id, array(
+		$this->search_manager->index(ext::TITANIA_FAQ, $this->faq_id, array(
 			'title'			=> $this->faq_subject,
 			'text'			=> $this->faq_text,
 			'text_uid'		=> $this->faq_text_uid,
@@ -212,7 +213,7 @@ class titania_faq extends \phpbb\titania\entity\message_base
 
 	public function delete()
 	{
-		$this->search_manager->delete(TITANIA_FAQ, $this->faq_id);
+		$this->search_manager->delete(ext::TITANIA_FAQ, $this->faq_id);
 
 		// Update the FAQ count
 		$sql = 'SELECT contrib_faq_count FROM ' . TITANIA_CONTRIBS_TABLE . '

--- a/includes/objects/post.php
+++ b/includes/objects/post.php
@@ -14,6 +14,7 @@
 use phpbb\titania\access;
 use phpbb\titania\contribution\type\collection as type_collection;
 use phpbb\titania\count;
+use phpbb\titania\ext;
 use phpbb\titania\message\message;
 
 /**
@@ -83,7 +84,7 @@ class titania_post extends \phpbb\titania\entity\message_base
 	 * @param object|bool|int $topic The topic object, topic_id to load it ourselves for an existing topic, boolean false for making a new post (we will create the topic object)
 	 * @param int $post_id The post_id, 0 for making a new post
 	 */
-	public function __construct($type = TITANIA_SUPPORT, $topic = false, $post_id = 0)
+	public function __construct($type = ext::TITANIA_SUPPORT, $topic = false, $post_id = 0)
 	{
 		// Configure object properties
 		$this->object_config = array_merge($this->object_config, array(
@@ -126,22 +127,22 @@ class titania_post extends \phpbb\titania\entity\message_base
 		switch ($type)
 		{
 			case 'queue_discussion' :
-			case TITANIA_QUEUE_DISCUSSION :
-				$this->post_type = TITANIA_QUEUE_DISCUSSION;
+			case ext::TITANIA_QUEUE_DISCUSSION :
+				$this->post_type = ext::TITANIA_QUEUE_DISCUSSION;
 			break;
 
 			case 'tracker' :
-			case TITANIA_TRACKER :
-				$this->post_type = TITANIA_TRACKER;
+			case ext::TITANIA_TRACKER :
+				$this->post_type = ext::TITANIA_TRACKER;
 			break;
 
 			case 'queue' :
-			case TITANIA_QUEUE :
-				$this->post_type = TITANIA_QUEUE;
+			case ext::TITANIA_QUEUE :
+				$this->post_type = ext::TITANIA_QUEUE;
 			break;
 
 			default :
-				$this->post_type = TITANIA_SUPPORT;
+				$this->post_type = ext::TITANIA_SUPPORT;
 			break;
 		}
 
@@ -244,7 +245,7 @@ class titania_post extends \phpbb\titania\entity\message_base
 	{
 		$params = $this->get_url_params($action, $use_anchor);
 		$controller = 'phpbb.titania.';
-		$controller .= ($this->post_type === TITANIA_QUEUE) ? 'queue.item' : 'contrib.support.topic';
+		$controller .= ($this->post_type === ext::TITANIA_QUEUE) ? 'queue.item' : 'contrib.support.topic';
 
 		if ($action)
 		{
@@ -265,7 +266,7 @@ class titania_post extends \phpbb\titania\entity\message_base
 		$params = unserialize($this->post_url);
 		$params['p'] = $this->post_id;
 
-		if ($this->post_type !== TITANIA_QUEUE)
+		if ($this->post_type !== ext::TITANIA_QUEUE)
 		{
 			$params['topic_id'] = $this->topic_id;
 		}
@@ -440,8 +441,8 @@ class titania_post extends \phpbb\titania\entity\message_base
 			// Setup the attention object and submit it
 			$attention = new titania_attention;
 			$attention->__set_array(array(
-				'attention_type'		=> TITANIA_ATTENTION_UNAPPROVED,
-				'attention_object_type'	=> TITANIA_POST,
+				'attention_type'		=> ext::TITANIA_ATTENTION_UNAPPROVED,
+				'attention_object_type'	=> ext::TITANIA_POST,
 				'attention_object_id'	=> $this->post_id,
 				'attention_poster_id'	=> $this->post_user_id,
 				'attention_post_time'	=> $this->post_time,
@@ -775,7 +776,7 @@ class titania_post extends \phpbb\titania\entity\message_base
 
 		// Remove any attention items
 		$sql = 'DELETE FROM ' . TITANIA_ATTENTION_TABLE . '
-			WHERE attention_object_type = ' . TITANIA_POST . '
+			WHERE attention_object_type = ' . ext::TITANIA_POST . '
 				AND attention_object_id = ' . $this->post_id;
 		phpbb::$db->sql_query($sql);
 
@@ -810,8 +811,8 @@ class titania_post extends \phpbb\titania\entity\message_base
 		// Setup the attention object and submit it
 		$attention = new titania_attention;
 		$attention->__set_array(array(
-			'attention_type'		=> TITANIA_ATTENTION_REPORTED,
-			'attention_object_type'	=> TITANIA_POST,
+			'attention_type'		=> ext::TITANIA_ATTENTION_REPORTED,
+			'attention_object_type'	=> ext::TITANIA_POST,
 			'attention_object_id'	=> $this->post_id,
 			'attention_poster_id'	=> $this->post_user_id,
 			'attention_post_time'	=> $this->post_time,
@@ -984,7 +985,7 @@ class titania_post extends \phpbb\titania\entity\message_base
 			'U_DELETE'						=> ($this->acl_get('delete') && (!$this->post_deleted || phpbb::$auth->acl_get('u_titania_post_hard_delete'))) ? $this->get_url('delete') : '',
 			'U_REPORT'						=> (phpbb::$user->data['is_registered']) ? $this->get_url('report') : '',
 			'U_WARN'						=> false, //$this->get_url('warn'),
-			'U_INFO'						=> (phpbb::$auth->acl_gets('u_titania_mod_author_mod', 'u_titania_mod_contrib_mod', 'u_titania_mod_faq_mod', 'u_titania_mod_post_mod') || $this->types->find_authed('moderate')) ? $this->controller_helper->route('phpbb.titania.manage.attention.redirect', array('type' => TITANIA_POST, 'id' => $this->post_id)) : '',
+			'U_INFO'						=> (phpbb::$auth->acl_gets('u_titania_mod_author_mod', 'u_titania_mod_contrib_mod', 'u_titania_mod_faq_mod', 'u_titania_mod_post_mod') || $this->types->find_authed('moderate')) ? $this->controller_helper->route('phpbb.titania.manage.attention.redirect', array('type' => ext::TITANIA_POST, 'id' => $this->post_id)) : '',
 			'U_QUOTE'						=> $this->acl_get('post') ? $this->get_url('quote') : '',
 
 			'S_UNREAD_POST'					=> ($this->unread) ? true : false, // remember that you must set this up extra...

--- a/includes/objects/queue.php
+++ b/includes/objects/queue.php
@@ -12,6 +12,7 @@
 */
 
 use phpbb\titania\access;
+use phpbb\titania\ext;
 use phpbb\titania\message\message;
 
 /**
@@ -39,7 +40,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 	 *
 	 * @var string
 	 */
-	protected $object_type = TITANIA_QUEUE;
+	protected $object_type = ext::TITANIA_QUEUE;
 
 	/** @var \phpbb\titania\controller\helper */
 	protected $controller_helper;
@@ -62,7 +63,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 			'queue_allow_repack'	=> array('default' => 1),
 
 			'queue_type'			=> array('default' => 0), // contrib type
-			'queue_status'			=> array('default' => TITANIA_QUEUE_HIDE), // Uses either TITANIA_QUEUE_NEW or one of the tags for the queue status from the DB
+			'queue_status'			=> array('default' => ext::TITANIA_QUEUE_HIDE), // Uses either TITANIA_QUEUE_NEW or one of the tags for the queue status from the DB
 			'queue_submit_time'		=> array('default' => titania::$time),
 			'queue_close_time'		=> array('default' => 0),
 			'queue_close_user'		=> array('default' => 0),
@@ -153,7 +154,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 			phpbb::$db->sql_freeresult();
 
 			// Create the topic
-			$post = new titania_post(TITANIA_QUEUE);
+			$post = new titania_post(ext::TITANIA_QUEUE);
 			$post->post_access = access::TEAM_LEVEL;
 			$post->topic->parent_id = $this->queue_id;
 			$post->topic->topic_category = $contrib_type;
@@ -186,7 +187,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		$queue_topic = $this->get_queue_discussion_topic();
 		$post->post_text .= '[url=' . $queue_topic->get_url() . ']' . phpbb::$user->lang['QUEUE_DISCUSSION_TOPIC'] . "[/url]\n\n";
 
-		if ($revision->revision_status == TITANIA_REVISION_ON_HOLD)
+		if ($revision->revision_status == ext::TITANIA_REVISION_ON_HOLD)
 		{
 			$post->post_text .= '<strong>' . phpbb::$user->lang['REVISION_FOR_NEXT_PHPBB'] . "</strong>\n\n";
 		}
@@ -243,7 +244,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 
 		$message = (isset(phpbb::$user->lang[$message])) ? phpbb::$user->lang[$message] : $message;
 
-		$post = new titania_post(TITANIA_QUEUE, $this->queue_topic_id);
+		$post = new titania_post(ext::TITANIA_QUEUE, $this->queue_topic_id);
 		$post->__set_array(array(
 			'post_subject'		=> 'Re: ' . $post->topic->topic_subject,
 			'post_text'			=> $message,
@@ -276,7 +277,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 
 		$topic = $this->get_queue_discussion_topic();
 
-		$post = new titania_post(TITANIA_QUEUE_DISCUSSION, $topic);
+		$post = new titania_post(ext::TITANIA_QUEUE_DISCUSSION, $topic);
 		$post->__set_array(array(
 			'post_subject'		=> 'Re: ' . $post->topic->topic_subject,
 			'post_text'			=> $message,
@@ -348,7 +349,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 			'U_VIEW_QUEUE'	=> $path_helper->strip_url_params($u_view_queue, 'sid'),
 		);
 		$this->subscriptions->send_notifications(
-			TITANIA_QUEUE_TAG,
+			ext::TITANIA_QUEUE_TAG,
 			$new_status,
 			'new_contrib_queue_cat',
 			$vars,
@@ -426,7 +427,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		$this->discussion_reply($message);
 
 		// Update the revisions
-		$revision->change_status(TITANIA_REVISION_APPROVED);
+		$revision->change_status(ext::TITANIA_REVISION_APPROVED);
 		$revision->submit();
 
 		// Reply to the release topic
@@ -444,7 +445,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		}
 
 		// Self-updating
-		$this->queue_status = TITANIA_QUEUE_APPROVED;
+		$this->queue_status = ext::TITANIA_QUEUE_APPROVED;
 		$this->queue_close_time = titania::$time;
 		$this->queue_close_user = phpbb::$user->data['user_id'];
 		$this->submit(false);
@@ -457,7 +458,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 			'NAME'		=> $contrib->contrib_name,
 			'U_VIEW'	=> $contrib->get_url(),
 		);
-		$this->subscriptions->send_notifications(TITANIA_CONTRIB, $this->contrib_id, 'subscribe_notify', $email_vars);
+		$this->subscriptions->send_notifications(ext::TITANIA_CONTRIB, $this->contrib_id, 'subscribe_notify', $email_vars);
 
 		// Hooks
 		titania::$hook->call_hook_ref(array(__CLASS__, __FUNCTION__), $this);
@@ -470,7 +471,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		$revision->change_status($revision_status);
 
 		// Self-updating
-		$this->queue_status = TITANIA_QUEUE_CLOSED;
+		$this->queue_status = ext::TITANIA_QUEUE_CLOSED;
 		$this->queue_close_time = titania::$time;
 		$this->queue_close_user = phpbb::$user->data['user_id'];
 		$this->submit(false);
@@ -499,10 +500,10 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		$this->discussion_reply($message);
 
 		// Update the revision
-		$revision->change_status(TITANIA_REVISION_DENIED);
+		$revision->change_status(ext::TITANIA_REVISION_DENIED);
 
 		// Self-updating
-		$this->queue_status = TITANIA_QUEUE_DENIED;
+		$this->queue_status = ext::TITANIA_QUEUE_DENIED;
 		$this->queue_close_time = titania::$time;
 		$this->queue_close_user = phpbb::$user->data['user_id'];
 		$this->submit(false);
@@ -621,7 +622,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 	{
 		$sql = 'SELECT * FROM ' . TITANIA_TOPICS_TABLE . '
 			WHERE parent_id = ' . $this->contrib_id . '
-				AND topic_type = ' . TITANIA_QUEUE_DISCUSSION;
+				AND topic_type = ' . ext::TITANIA_QUEUE_DISCUSSION;
 		$result = phpbb::$db->sql_query($sql);
 		$row = phpbb::$db->sql_fetchrow($result);
 		phpbb::$db->sql_freeresult($result);
@@ -644,7 +645,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 
 		$contrib = contribs_overlord::get_contrib_object($this->contrib_id, true);
 
-		$post = new titania_post(TITANIA_QUEUE_DISCUSSION);
+		$post = new titania_post(ext::TITANIA_QUEUE_DISCUSSION);
 		$post->topic->__set_array(array(
 			'parent_id'			=> $this->contrib_id,
 			'topic_category'	=> $contrib->contrib_type,

--- a/includes/objects/rating.php
+++ b/includes/objects/rating.php
@@ -11,6 +11,8 @@
 *
 */
 
+use phpbb\titania\ext;
+
 /**
 * Class to abstract titania ratings.
 * @package Titania
@@ -135,7 +137,7 @@ class titania_rating extends \phpbb\titania\entity\database_base
 		switch($this->rating_type)
 		{
 			case 'author' :
-				$this->rating_type_id = TITANIA_AUTHOR;
+				$this->rating_type_id = ext::TITANIA_AUTHOR;
 				$this->cache_table = TITANIA_AUTHORS_TABLE;
 				$this->cache_rating = 'author_rating';
 				$this->cache_rating_count = 'author_rating_count';
@@ -143,7 +145,7 @@ class titania_rating extends \phpbb\titania\entity\database_base
 			break;
 
 			case 'contrib' :
-				$this->rating_type_id = TITANIA_CONTRIB;
+				$this->rating_type_id = ext::TITANIA_CONTRIB;
 				$this->cache_table = TITANIA_CONTRIBS_TABLE;
 				$this->cache_rating = 'contrib_rating';
 				$this->cache_rating_count = 'contrib_rating_count';

--- a/includes/objects/revision.php
+++ b/includes/objects/revision.php
@@ -14,8 +14,9 @@
 use phpbb\config\config;
 use phpbb\titania\attachment\attachment;
 use phpbb\titania\composer\repository;
-use phpbb\titania\versions;
+use phpbb\titania\ext;
 use phpbb\titania\message\message;
+use phpbb\titania\versions;
 
 /**
 * Class to titania revision.
@@ -79,7 +80,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 		$this->object_config = array_merge($this->object_config, array(
 			'revision_id'				=> array('default' => 0),
 			'contrib_id' 				=> array('default' => 0),
-			'revision_status'			=> array('default' => TITANIA_REVISION_NEW),
+			'revision_status'			=> array('default' => ext::TITANIA_REVISION_NEW),
 			'attachment_id' 			=> array('default' => 0),
 			'revision_name' 			=> array('default' => '', 'max' => 255),
 			'revision_time'				=> array('default' => (int) titania::$time),
@@ -186,7 +187,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 	public function load_translations()
 	{
 		$this->translations
-			->configure(TITANIA_TRANSLATION, $this->revision_id)
+			->configure(ext::TITANIA_TRANSLATION, $this->revision_id)
 			->load()
 		;
 	}
@@ -232,7 +233,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 
         // ColorizeIt stuff
         $url_colorizeit = '';
-        if($this->revision_status == TITANIA_REVISION_APPROVED && strlen(titania::$config->colorizeit) && $this->contrib && $this->contrib->has_colorizeit())
+        if($this->revision_status == ext::TITANIA_REVISION_APPROVED && strlen(titania::$config->colorizeit) && $this->contrib && $this->contrib->has_colorizeit())
         {
             $url_colorizeit = 'http://' . titania::$config->colorizeit_url . '/custom/' . titania::$config->colorizeit . '.html?id=' . $this->attachment_id . '&amp;sample=' . $this->contrib->clr_sample->get_id();
         }
@@ -259,13 +260,13 @@ class titania_revision extends \phpbb\titania\entity\database_base
 			'U_EDIT'			=> ($this->contrib && ($this->contrib->is_author || $this->contrib->is_active_coauthor || $this->contrib->type->acl_get('moderate'))) ? $this->contrib->get_url('revision', array('page' => 'edit', 'id' => $this->revision_id)) : '',
 
 			'S_USE_QUEUE'			=> (titania::$config->use_queue && $this->contrib->type->use_queue) ? true : false,
-			'S_NEW'					=> ($this->revision_status == TITANIA_REVISION_NEW) ? true : false,
-			'S_APPROVED'			=> ($this->revision_status == TITANIA_REVISION_APPROVED) ? true : false,
-			'S_DENIED'				=> ($this->revision_status == TITANIA_REVISION_DENIED) ? true : false,
-			'S_PULLED_SECURITY'		=> ($this->revision_status == TITANIA_REVISION_PULLED_SECURITY) ? true : false,
-			'S_PULLED_OTHER'		=> ($this->revision_status == TITANIA_REVISION_PULLED_OTHER) ? true : false,
-			'S_REPACKED'			=> ($this->revision_status == TITANIA_REVISION_REPACKED) ? true : false,
-			'S_RESUBMITTED'			=> ($this->revision_status == TITANIA_REVISION_RESUBMITTED) ? true : false,
+			'S_NEW'					=> ($this->revision_status == ext::TITANIA_REVISION_NEW) ? true : false,
+			'S_APPROVED'			=> ($this->revision_status == ext::TITANIA_REVISION_APPROVED) ? true : false,
+			'S_DENIED'				=> ($this->revision_status == ext::TITANIA_REVISION_DENIED) ? true : false,
+			'S_PULLED_SECURITY'		=> ($this->revision_status == ext::TITANIA_REVISION_PULLED_SECURITY) ? true : false,
+			'S_PULLED_OTHER'		=> ($this->revision_status == ext::TITANIA_REVISION_PULLED_OTHER) ? true : false,
+			'S_REPACKED'			=> ($this->revision_status == ext::TITANIA_REVISION_REPACKED) ? true : false,
+			'S_RESUBMITTED'			=> ($this->revision_status == ext::TITANIA_REVISION_RESUBMITTED) ? true : false,
 		));
 
 		phpbb::$user->date_format = $old_date_format;
@@ -316,7 +317,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 					'U_VIEW'	=> $this->contrib->get_url(),
 				);
 				$this->subscriptions->send_notifications(
-					TITANIA_CONTRIB,
+					ext::TITANIA_CONTRIB,
 					$this->contrib_id,
 					'subscribe_notify',
 					$email_vars
@@ -359,7 +360,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 				$sql_ary[] = array(
 					'revision_id'				=> $this->revision_id,
 					'contrib_id'				=> $this->contrib_id,
-					'revision_validated'		=> ($this->revision_status == TITANIA_REVISION_APPROVED) ? true : false,
+					'revision_validated'		=> ($this->revision_status == ext::TITANIA_REVISION_APPROVED) ? true : false,
 					'phpbb_version_branch'		=> $row['phpbb_version_branch'],
 					'phpbb_version_revision'	=> $this->get_real_phpbb_version(((isset($row['phpbb_version_revision'])) ? $row['phpbb_version_revision'] : titania::$config->phpbb_versions[$row['phpbb_version_branch']]['latest_revision'])),
 				);
@@ -372,7 +373,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 		}
 
 		// Update the release topic
-		if ($this->revision_status == TITANIA_REVISION_APPROVED)
+		if ($this->revision_status == ext::TITANIA_REVISION_APPROVED)
 		{
 			$this->contrib->update_release_topic();
 		}
@@ -404,10 +405,10 @@ class titania_revision extends \phpbb\titania\entity\database_base
 
 		switch ($old_status)
 		{
-			case TITANIA_REVISION_APPROVED :
+			case ext::TITANIA_REVISION_APPROVED :
 				// If there are no approved revisions left we will need to reset the contribution status
 				$sql = 'SELECT COUNT(revision_id) AS cnt FROM ' . TITANIA_REVISIONS_TABLE . '
-					WHERE revision_status = ' . TITANIA_REVISION_APPROVED . '
+					WHERE revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
 						AND contrib_id = ' . $this->contrib_id . '
 						AND revision_id <> ' . $this->revision_id;
 				phpbb::$db->sql_query($sql);
@@ -420,9 +421,9 @@ class titania_revision extends \phpbb\titania\entity\database_base
 						$this->contrib = contribs_overlord::get_contrib_object($this->contrib_id, true);
 					}
 
-					if (in_array($this->contrib->contrib_status, array(TITANIA_CONTRIB_APPROVED, TITANIA_CONTRIB_DOWNLOAD_DISABLED)))
+					if (in_array($this->contrib->contrib_status, array(ext::TITANIA_CONTRIB_APPROVED, ext::TITANIA_CONTRIB_DOWNLOAD_DISABLED)))
 					{
-						$this->contrib->change_status(TITANIA_CONTRIB_NEW);
+						$this->contrib->change_status(ext::TITANIA_CONTRIB_NEW);
 					}
 				}
 			break;
@@ -430,16 +431,16 @@ class titania_revision extends \phpbb\titania\entity\database_base
 
 		switch ($new_status)
 		{
-			case TITANIA_REVISION_APPROVED :
+			case ext::TITANIA_REVISION_APPROVED :
 				// If approving this revision and the contribution is set to new, approve the contribution
 				if (!$this->contrib)
 				{
 					$this->contrib = contribs_overlord::get_contrib_object($this->contrib_id, true);
 				}
 
-				if (in_array($this->contrib->contrib_status, array(TITANIA_CONTRIB_NEW)))
+				if (in_array($this->contrib->contrib_status, array(ext::TITANIA_CONTRIB_NEW)))
 				{
-					$this->contrib->change_status(TITANIA_CONTRIB_APPROVED);
+					$this->contrib->change_status(ext::TITANIA_CONTRIB_APPROVED);
 				}
 				repository::trigger_cron($this->config);
 
@@ -453,7 +454,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 
 				// Update the contributions table if this is the newest validated revision
 				$sql = 'SELECT revision_id FROM ' . $this->sql_table . '
-					WHERE revision_status = ' . TITANIA_REVISION_APPROVED . '
+					WHERE revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
 					AND contrib_id = ' . $this->contrib_id . '
 					ORDER BY revision_id DESC';
 				phpbb::$db->sql_query_limit($sql, 1);
@@ -488,7 +489,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 		phpbb::$db->sql_query($sql);
 
 		// Update the release topic
-		if ($this->revision_status == TITANIA_REVISION_APPROVED)
+		if ($this->revision_status == ext::TITANIA_REVISION_APPROVED)
 		{
 			$this->contrib->update_release_topic();
 		}
@@ -544,7 +545,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 		$queue->delete();
 
 		// Unlink the old queue_id from the old revision and set it to repacked
-		$old_revision->change_status(TITANIA_REVISION_REPACKED);
+		$old_revision->change_status(ext::TITANIA_REVISION_REPACKED);
 		$old_revision->revision_queue_id = 0;
 		$old_revision->submit();
 
@@ -555,7 +556,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 		// Move any translations
 		$sql = 'UPDATE ' . TITANIA_ATTACHMENTS_TABLE . '
 			SET object_id = ' . $this->revision_id . '
-			WHERE object_type = ' . TITANIA_TRANSLATION . '
+			WHERE object_type = ' . ext::TITANIA_TRANSLATION . '
 				AND object_id = ' . $old_revision->revision_id;
 		phpbb::$db->sql_query($sql);
 
@@ -579,7 +580,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 		// Delete the attachment
 		$operator = phpbb::$container->get('phpbb.titania.attachment.operator');
 		$operator
-			->configure(TITANIA_CONTRIB, $this->contrib_id)
+			->configure(ext::TITANIA_CONTRIB, $this->contrib_id)
 			->load(array($this->attachment_id))
 			->delete(array($this->attachment_id))
 		;
@@ -607,7 +608,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 			$queue = $this->get_queue();
 
 			// Only create the queue for revisions set as new
-			if ($queue === false && ($this->revision_status == TITANIA_REVISION_NEW || $this->revision_status == TITANIA_REVISION_ON_HOLD))
+			if ($queue === false && ($this->revision_status == ext::TITANIA_REVISION_NEW || $this->revision_status == ext::TITANIA_REVISION_ON_HOLD))
 			{
 				$queue = new titania_queue;
 			}
@@ -622,7 +623,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 				));
 
 				// Set the queue status to new if it's submitted and the queue status is set to hide it
-				if ($this->revision_submitted && $queue->queue_status == TITANIA_QUEUE_HIDE)
+				if ($this->revision_submitted && $queue->queue_status == ext::TITANIA_QUEUE_HIDE)
 				{
 					// Only set the queue as new if there are not any newer revisions in the queue
 					$sql = 'SELECT queue_id FROM ' . TITANIA_QUEUE_TABLE . '
@@ -631,7 +632,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 					$result = phpbb::$db->sql_query($sql);
 					if(!($row = phpbb::$db->sql_fetchrow($result)))
 					{
-						$queue->queue_status = TITANIA_QUEUE_NEW;
+						$queue->queue_status = ext::TITANIA_QUEUE_NEW;
 					}
 				}
 
@@ -654,13 +655,13 @@ class titania_revision extends \phpbb\titania\entity\database_base
 						WHERE contrib_id = ' . (int) $this->contrib_id . '
 							AND revision_id < ' . $this->revision_id . "
 							$exclude
-							AND queue_status = " . TITANIA_QUEUE_NEW;
+							AND queue_status = " . ext::TITANIA_QUEUE_NEW;
 					$result = phpbb::$db->sql_query($sql);
 					while ($row = phpbb::$db->sql_fetchrow($result))
 					{
 						$queue = new titania_queue;
 						$queue->__set_array($row);
-						$queue->close(TITANIA_REVISION_RESUBMITTED);
+						$queue->close(ext::TITANIA_REVISION_RESUBMITTED);
 						unset($queue);
 					}
 					phpbb::$db->sql_freeresult($result);

--- a/includes/objects/topic.php
+++ b/includes/objects/topic.php
@@ -13,6 +13,7 @@
 
 use phpbb\titania\access;
 use phpbb\titania\count;
+use phpbb\titania\ext;
 use phpbb\titania\url\url;
 
 /**
@@ -188,12 +189,12 @@ class titania_topic extends \phpbb\titania\entity\database_base
 
 		// Remove any subscriptions to this topic
 		$sql = 'DELETE FROM ' . TITANIA_WATCH_TABLE . '
-			WHERE watch_object_type = ' . TITANIA_TOPIC . '
+			WHERE watch_object_type = ' . ext::TITANIA_TOPIC . '
 				AND watch_object_id = ' . $this->topic_id;
 		phpbb::$db->sql_query($sql);
 
 		// Remove any tracking for this topic
-		$this->tracking->clear_item(TITANIA_TOPIC, $this->topic_id);
+		$this->tracking->clear_item(ext::TITANIA_TOPIC, $this->topic_id);
 
 		// Delete the now empty topic
 		$sql = 'DELETE FROM ' . TITANIA_TOPICS_TABLE . '
@@ -232,13 +233,13 @@ class titania_topic extends \phpbb\titania\entity\database_base
 
 		switch ($this->topic_type)
 		{
-			case TITANIA_SUPPORT:
-			case TITANIA_QUEUE_DISCUSSION:
+			case ext::TITANIA_SUPPORT:
+			case ext::TITANIA_QUEUE_DISCUSSION:
 				$controller = 'phpbb.titania.contrib.support.topic';
 				$params['topic_id'] = $this->topic_id;
 			break;
 
-			case TITANIA_QUEUE:
+			case ext::TITANIA_QUEUE:
 				$controller = 'phpbb.titania.queue.item';
 				$params['id'] = $this->parent_id;
 			break;
@@ -262,12 +263,12 @@ class titania_topic extends \phpbb\titania\entity\database_base
 
 		switch ($this->topic_type)
 		{
-			case TITANIA_SUPPORT:
-			case TITANIA_QUEUE_DISCUSSION:
+			case ext::TITANIA_SUPPORT:
+			case ext::TITANIA_QUEUE_DISCUSSION:
 				$controller = 'phpbb.titania.contrib.support';
 			break;
 
-			case TITANIA_QUEUE:
+			case ext::TITANIA_QUEUE:
 				$controller = 'phpbb.titania.queue.item';
 			break;
 		}
@@ -333,7 +334,7 @@ class titania_topic extends \phpbb\titania\entity\database_base
 	public function assign_details()
 	{
 		// Tracking check
-		$last_read_mark = $this->tracking->get_track(TITANIA_TOPIC, $this->topic_id, true);
+		$last_read_mark = $this->tracking->get_track(ext::TITANIA_TOPIC, $this->topic_id, true);
 		$last_read_mark = max($last_read_mark, $this->tracking->find_last_read_mark($this->additional_unread_fields, $this->topic_type, $this->parent_id));
 		$this->unread = ($this->topic_last_post_time > $last_read_mark) ? true : false;
 
@@ -544,7 +545,7 @@ class titania_topic extends \phpbb\titania\entity\database_base
 		$this->topic_approved = (!$visible_posts && !$first_post_data['post_approved']) ? 0 : 1;
 
 		// Adjust the topic access
-		if ($visible_posts && !in_array($this->topic_type, array(TITANIA_QUEUE_DISCUSSION, TITANIA_QUEUE)))
+		if ($visible_posts && !in_array($this->topic_type, array(ext::TITANIA_QUEUE_DISCUSSION, ext::TITANIA_QUEUE)))
 		{
 			$this->topic_access = access::PUBLIC_LEVEL;
 

--- a/includes/overlords/attention.php
+++ b/includes/overlords/attention.php
@@ -11,6 +11,8 @@
 *
 */
 
+use phpbb\titania\ext;
+
 class attention_overlord
 {
 	// Attention items
@@ -41,12 +43,12 @@ class attention_overlord
 
 		switch ($data['attention_object_type'])
 		{
-			case TITANIA_POST:
+			case ext::TITANIA_POST:
 				titania::_include('objects/attention_types/post', false, 'titania_attention_post');
 				$object = new titania_attention_post();
 			break;
 
-			case TITANIA_CONTRIB:
+			case ext::TITANIA_CONTRIB:
 				titania::_include('objects/attention_types/contribution', false, 'titania_attention_contribution');
 				$object = new titania_attention_contribution();
 			break;
@@ -70,7 +72,7 @@ class attention_overlord
 	{
 		$sql = 'SELECT a.* FROM ' . TITANIA_ATTENTION_TABLE . ' a
 			LEFT JOIN ' . TITANIA_CONTRIBS_TABLE . ' c
-				ON (a.attention_object_type = ' . TITANIA_CONTRIB . ' AND a.attention_object_id = c.contrib_id)
+				ON (a.attention_object_type = ' . ext::TITANIA_CONTRIB . ' AND a.attention_object_id = c.contrib_id)
 			WHERE ';
 
 		if ($attention_id)
@@ -137,7 +139,7 @@ class attention_overlord
 			'LEFT_JOIN'	=> array(
 				array(
 					'FROM'	=> array(TITANIA_CONTRIBS_TABLE => 'c'),
-					'ON'	=> 'a.attention_object_type = ' . TITANIA_CONTRIB . ' AND a.attention_object_id = c.contrib_id',
+					'ON'	=> 'a.attention_object_type = ' . ext::TITANIA_CONTRIB . ' AND a.attention_object_id = c.contrib_id',
 				),
 			),
 
@@ -274,23 +276,23 @@ class attention_overlord
 
 		if (phpbb::$auth->acl_get('u_titania_mod_post_mod'))
 		{
-			$sql_where .= '(a.attention_object_type = ' . TITANIA_POST . ')';
+			$sql_where .= '(a.attention_object_type = ' . ext::TITANIA_POST . ')';
 			$negated = false;
 		}
 		else
 		{
-			$sql_where .= '(a.attention_object_type <> ' . TITANIA_POST . ')';
+			$sql_where .= '(a.attention_object_type <> ' . ext::TITANIA_POST . ')';
 			$negated = true;
 		}
 
 		if (!empty($types_managed))
 		{
 			$sql_where .= ($negated) ? ' AND ' : ' OR ';
-			$sql_where .= '(a.attention_object_type = ' . TITANIA_CONTRIB . ' AND ' . phpbb::$db->sql_in_set('c.contrib_type', $types_managed) . ')';
+			$sql_where .= '(a.attention_object_type = ' . ext::TITANIA_CONTRIB . ' AND ' . phpbb::$db->sql_in_set('c.contrib_type', $types_managed) . ')';
 		}
 		else
 		{
-			$sql_where .= 'AND (a.attention_object_type <> ' . TITANIA_CONTRIB . ')';
+			$sql_where .= 'AND (a.attention_object_type <> ' . ext::TITANIA_CONTRIB . ')';
 		}
 
 		return '(' . $sql_where . ')';

--- a/includes/overlords/contribs.php
+++ b/includes/overlords/contribs.php
@@ -11,6 +11,7 @@
 *
 */
 
+use phpbb\titania\ext;
 use phpbb\titania\message\message;
 use phpbb\titania\versions;
 
@@ -160,7 +161,7 @@ class contribs_overlord
 						array(
 							'FROM'	=> array(TITANIA_ATTACHMENTS_TABLE => 'a'),
 							'ON'	=> 'c.contrib_id = a.object_id
-								AND a.object_type = ' . TITANIA_SCREENSHOT . '
+								AND a.object_type = ' . ext::TITANIA_SCREENSHOT . '
 								AND a.is_orphan = 0
 								AND a.is_preview = 1',
 						),
@@ -193,7 +194,7 @@ class contribs_overlord
 						array(
 							'FROM'	=> array(TITANIA_ATTACHMENTS_TABLE => 'a'),
 							'ON'	=> 'c.contrib_id = a.object_id
-								AND a.object_type = ' . TITANIA_SCREENSHOT . '
+								AND a.object_type = ' . ext::TITANIA_SCREENSHOT . '
 								AND a.is_orphan = 0
 								AND a.is_preview = 1',
 						)
@@ -224,7 +225,7 @@ class contribs_overlord
 						array(
 							'FROM'	=> array(TITANIA_ATTACHMENTS_TABLE => 'a'),
 							'ON'	=> 'c.contrib_id = a.object_id
-								AND a.object_type = ' . TITANIA_SCREENSHOT . '
+								AND a.object_type = ' . ext::TITANIA_SCREENSHOT . '
 								AND a.is_orphan = 0
 								AND a.is_preview = 1',
 						),
@@ -238,7 +239,7 @@ class contribs_overlord
 			break;
 		}
 
-		$tracking->get_track_sql($sql_ary, TITANIA_CONTRIB, 'c.contrib_id');
+		$tracking->get_track_sql($sql_ary, ext::TITANIA_CONTRIB, 'c.contrib_id');
 
 		$mod_contrib_mod = (bool) phpbb::$auth->acl_get('u_titania_mod_contrib_mod');
 
@@ -262,7 +263,7 @@ class contribs_overlord
 			}
 
 			$view_unapproved = array_unique($view_unapproved);
-			$sql_ary['WHERE'] .= ' AND (' . phpbb::$db->sql_in_set('c.contrib_status', array(TITANIA_CONTRIB_APPROVED, TITANIA_CONTRIB_DOWNLOAD_DISABLED)) .
+			$sql_ary['WHERE'] .= ' AND (' . phpbb::$db->sql_in_set('c.contrib_status', array(ext::TITANIA_CONTRIB_APPROVED, ext::TITANIA_CONTRIB_DOWNLOAD_DISABLED)) .
 				((sizeof($view_unapproved)) ? ' OR ' . phpbb::$db->sql_in_set('c.contrib_type', array_map('intval', $view_unapproved)) : '') . '
 				OR c.contrib_user_id = ' . phpbb::$user->data['user_id'] . '
 				OR cc.active = 1)';
@@ -294,7 +295,7 @@ class contribs_overlord
 			if (!$mod_contrib_mod && $row['contrib_user_id'] != phpbb::$user->data['user_id'] && $row['coauthor'] != phpbb::$user->data['user_id'] && !$access->is_team())
 			{
 				//If the contribution has a status that is not accessible by the current user let's not add it
-				if (in_array($row['contrib_status'], array(TITANIA_CONTRIB_NEW, TITANIA_CONTRIB_CLEANED, TITANIA_CONTRIB_HIDDEN, TITANIA_CONTRIB_DISABLED)))
+				if (in_array($row['contrib_status'], array(ext::TITANIA_CONTRIB_NEW, ext::TITANIA_CONTRIB_CLEANED, ext::TITANIA_CONTRIB_HIDDEN, ext::TITANIA_CONTRIB_DISABLED)))
 				{
 					continue;
 				}
@@ -344,7 +345,7 @@ class contribs_overlord
 		$author_contribs = titania::$cache->get_author_contribs(phpbb::$user->data['user_id'], $types, phpbb::$user, true);
 
 		// Get the mark all tracking
-		$tracking->get_track(TITANIA_CONTRIB, 0);
+		$tracking->get_track(ext::TITANIA_CONTRIB, 0);
 
 		foreach ($contrib_ids as $contrib_id)
 		{
@@ -370,8 +371,8 @@ class contribs_overlord
 
 			// Get the folder image
 			$folder_img = $folder_alt = '';
-			$last_read_mark = $tracking->get_track(TITANIA_CONTRIB, $contrib->contrib_id, true);
-			$last_complete_mark = $tracking->get_track(TITANIA_CONTRIB, 0, true);
+			$last_read_mark = $tracking->get_track(ext::TITANIA_CONTRIB, $contrib->contrib_id, true);
+			$last_complete_mark = $tracking->get_track(ext::TITANIA_CONTRIB, 0, true);
 			$is_unread = ($contrib->contrib_last_update > $last_read_mark && $contrib->contrib_last_update > $last_complete_mark) ? true : false;
 			phpbb::$container->get('phpbb.titania.display')->topic_folder_img($folder_img, $folder_alt, 0, $is_unread);
 

--- a/includes/overlords/posts.php
+++ b/includes/overlords/posts.php
@@ -11,6 +11,7 @@
 *
 */
 
+use phpbb\titania\ext;
 use phpbb\titania\message\message;
 
 class posts_overlord
@@ -164,7 +165,7 @@ $sort_by_post_sql = array('a' => 'u.username_clean', 't' => 'p.post_id', 's' => 
 		if (phpbb::$request->variable('view', '') == 'unread')
 		{
 			$tracking = phpbb::$container->get('phpbb.titania.tracking');
-			$mark_time = $tracking->get_track(TITANIA_TOPIC, $topic->topic_id);
+			$mark_time = $tracking->get_track(ext::TITANIA_TOPIC, $topic->topic_id);
 
 			if ($mark_time > 0)
 			{
@@ -191,7 +192,7 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 		self::assign_common();
 
 		// Build Quick Actions
-		if ($topic->topic_type != TITANIA_QUEUE)
+		if ($topic->topic_type != ext::TITANIA_QUEUE)
 		{
 			self::build_quick_actions($topic);
 		}
@@ -281,10 +282,10 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 		phpbb::$db->sql_freeresult($result);
 
 		// Grab the tracking data
-		$last_mark_time = $tracking->get_track(TITANIA_TOPIC, $topic->topic_id);
+		$last_mark_time = $tracking->get_track(ext::TITANIA_TOPIC, $topic->topic_id);
 
 		// Store tracking data
-		$tracking->track(TITANIA_TOPIC, $topic->topic_id, $last_post_time);
+		$tracking->track(ext::TITANIA_TOPIC, $topic->topic_id, $last_post_time);
 
 		// load the user data
 		users_overlord::load($user_ids);
@@ -454,8 +455,8 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 			'MAKE_STICKY'		=> (!$topic->topic_sticky) ? $topic->get_url('sticky_topic') : false,
 			'LOCK_TOPIC'		=> (!$topic->topic_locked) ? $topic->get_url('lock_topic') : false,
 			'UNLOCK_TOPIC'		=> ($topic->topic_locked) ? $topic->get_url('unlock_topic') : false,
-			'SPLIT_TOPIC'		=> ($is_moderator && $topic->topic_type == TITANIA_SUPPORT) ? $topic->get_url('split_topic') : false,
-			'MERGE_POSTS'		=> ($is_moderator && $topic->topic_type == TITANIA_SUPPORT) ? $topic->get_url('move_posts') : false,
+			'SPLIT_TOPIC'		=> ($is_moderator && $topic->topic_type == ext::TITANIA_SUPPORT) ? $topic->get_url('split_topic') : false,
+			'MERGE_POSTS'		=> ($is_moderator && $topic->topic_type == ext::TITANIA_SUPPORT) ? $topic->get_url('move_posts') : false,
 			'SOFT_DELETE_TOPIC'	=> $topic->get_url('delete_topic'),
 			'UNDELETE_TOPIC'	=> $topic->get_url('undelete_topic'),
 		);

--- a/includes/overlords/queue.php
+++ b/includes/overlords/queue.php
@@ -11,6 +11,8 @@
 *
 */
 
+use phpbb\titania\ext;
+
 class queue_overlord
 {
 	/**
@@ -91,7 +93,7 @@ class queue_overlord
 	* @param string $type The type of queue (the contrib type)
 	* @param object|boolean $sort The sort object (includes/tools/sort.php)
 	*/
-	public static function display_queue($type, $queue_status = TITANIA_QUEUE_NEW, $sort = false)
+	public static function display_queue($type, $queue_status = ext::TITANIA_QUEUE_NEW, $sort = false)
 	{
 		if ($sort === false)
 		{
@@ -142,7 +144,7 @@ class queue_overlord
 			'ON'	=> 't.topic_last_post_user_id = ul.user_id',
 		);
 
-		$tracking->get_track_sql($sql_ary, TITANIA_TOPIC, 't.topic_id');
+		$tracking->get_track_sql($sql_ary, ext::TITANIA_TOPIC, 't.topic_id');
 
 		// Main SQL Query
 		$sql = phpbb::$db->sql_build_query('SELECT', $sql_ary);
@@ -332,7 +334,7 @@ class queue_overlord
 				),
 			));
 
-			$tags = titania::$cache->get_tags(TITANIA_QUEUE);
+			$tags = titania::$cache->get_tags(ext::TITANIA_QUEUE);
 			unset($tags[$row['queue_status']]);
 
 			$quick_actions = array(
@@ -478,7 +480,7 @@ class queue_overlord
 
 		// Subscriptions
 		phpbb::$container->get('phpbb.titania.subscriptions')->handle_subscriptions(
-			TITANIA_TOPIC,
+			ext::TITANIA_TOPIC,
 			$topic->topic_id,
 			$controller_helper->get_current_url(),
 			'SUBSCRIBE_TOPIC'
@@ -497,7 +499,7 @@ class queue_overlord
 		$controller_helper = phpbb::$container->get('phpbb.titania.controller.helper');
 		$types = phpbb::$container->get('phpbb.titania.contribution.type.collection');
 
-		$tags = titania::$cache->get_tags(TITANIA_QUEUE);
+		$tags = titania::$cache->get_tags(ext::TITANIA_QUEUE);
 		$tag_count = array();
 		$total = 0;
 		$type_url = $types->get($type)->url;

--- a/includes/overlords/topics.php
+++ b/includes/overlords/topics.php
@@ -11,6 +11,8 @@
 *
 */
 
+use phpbb\titania\ext;
+
 class topics_overlord
 {
 	/**
@@ -234,7 +236,7 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 			'ON'	=> 't.topic_last_post_user_id = ul.user_id',
 		);
 
-		$tracking->get_track_sql($sql_ary, TITANIA_TOPIC, 't.topic_id');
+		$tracking->get_track_sql($sql_ary, ext::TITANIA_TOPIC, 't.topic_id');
 
 		// Setup the contribution/topic we will use for parsing the output (before the switch so we are able to do type specific things for it)
 		$topic = new titania_topic();
@@ -246,7 +248,7 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 			case 'tracker' :
 				$page_url = $object->get_url('tracker');
 				$sql_ary['WHERE'] .= ' AND t.parent_id = ' . (int) $object->contrib_id;
-				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . TITANIA_TRACKER;
+				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . ext::TITANIA_TRACKER;
 
 				if (isset($options['category']))
 				{
@@ -256,14 +258,14 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 
 			case 'queue' :
 				$page_url = $controller_helper->route('phpbb.titania.queue');
-				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . TITANIA_QUEUE;
+				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . ext::TITANIA_QUEUE;
 			break;
 
 			case 'queue_discussion' :
 				$page_url = $controller_helper->route('phpbb.titania.queue_discussion.type', array(
 					'queue_type' => $types->get($options['topic_category'])->url,
 				));
-				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . TITANIA_QUEUE_DISCUSSION;
+				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . ext::TITANIA_QUEUE_DISCUSSION;
 
 				// Only display those in which the users are authed
 				$authed = $types->find_authed('queue_discussion');
@@ -286,12 +288,12 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 				}
 
 				// Additional tracking for all queue discussion topics
-				$tracking->get_track_sql($sql_ary, TITANIA_QUEUE_DISCUSSION, 0, 'tqt');
-				$topic->additional_unread_fields[] = array('type' => TITANIA_QUEUE_DISCUSSION, 'id' => 0, 'type_match' => true);
+				$tracking->get_track_sql($sql_ary, ext::TITANIA_QUEUE_DISCUSSION, 0, 'tqt');
+				$topic->additional_unread_fields[] = array('type' => ext::TITANIA_QUEUE_DISCUSSION, 'id' => 0, 'type_match' => true);
 
 				// Additional tracking for marking items as read in each contribution
-				$tracking->get_track_sql($sql_ary, TITANIA_SUPPORT, 't.parent_id', 'tst');
-				$topic->additional_unread_fields[] = array('type' => TITANIA_SUPPORT, 'parent_match' => true);
+				$tracking->get_track_sql($sql_ary, ext::TITANIA_SUPPORT, 't.parent_id', 'tst');
+				$topic->additional_unread_fields[] = array('type' => ext::TITANIA_SUPPORT, 'parent_match' => true);
 			break;
 
 			case 'author_support' :
@@ -300,24 +302,24 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 				$sql_ary['WHERE'] .= ' AND ' . phpbb::$db->sql_in_set('t.parent_id', array_map('intval', $contrib_ids));
 
 				// We also display the queue discussion topic between validators and authors in the support area
-				$sql_ary['WHERE'] .= ' AND (t.topic_type = ' . TITANIA_SUPPORT . ' OR t.topic_type = ' . TITANIA_QUEUE_DISCUSSION . ')';
+				$sql_ary['WHERE'] .= ' AND (t.topic_type = ' . ext::TITANIA_SUPPORT . ' OR t.topic_type = ' . ext::TITANIA_QUEUE_DISCUSSION . ')';
 
 				// Do not display abandoned contribs in the author's support section
 				$sql_ary['WHERE'] .= 'AND contrib.contrib_limited_support = 0';
 
 				// Additional tracking for marking items as read in each contribution
-				$tracking->get_tracks(TITANIA_SUPPORT, $contrib_ids);
-				$topic->additional_unread_fields[] = array('type' => TITANIA_SUPPORT, 'parent_match' => true);
+				$tracking->get_tracks(ext::TITANIA_SUPPORT, $contrib_ids);
+				$topic->additional_unread_fields[] = array('type' => ext::TITANIA_SUPPORT, 'parent_match' => true);
 
 				// Additional tracking for all support topics
-				$tracking->get_track_sql($sql_ary, TITANIA_ALL_SUPPORT, 0, 'tstg');
-				$topic->additional_unread_fields[] = array('type' => TITANIA_ALL_SUPPORT, 'id' => 0);
+				$tracking->get_track_sql($sql_ary, ext::TITANIA_ALL_SUPPORT, 0, 'tstg');
+				$topic->additional_unread_fields[] = array('type' => ext::TITANIA_ALL_SUPPORT, 'id' => 0);
 
 				// Track the queue discussion too if applicable
 				if ($types->find_authed('queue_discussion'))
 				{
-					$tracking->get_track_sql($sql_ary, TITANIA_QUEUE_DISCUSSION, 0, 'tqt');
-					$topic->additional_unread_fields[] = array('type' => TITANIA_QUEUE_DISCUSSION, 'id' => 0, 'type_match' => true);
+					$tracking->get_track_sql($sql_ary, ext::TITANIA_QUEUE_DISCUSSION, 0, 'tqt');
+					$topic->additional_unread_fields[] = array('type' => ext::TITANIA_QUEUE_DISCUSSION, 'id' => 0, 'type_match' => true);
 				}
 
 				// Try to grab the category/contrib name
@@ -339,7 +341,7 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 				$contrib_ids = titania::$cache->get_author_contribs($object->user_id, $types, phpbb::$user);
 				$sql_ary['WHERE'] .= ' AND ' . phpbb::$db->sql_in_set('t.parent_id', array_map('intval', $contrib_ids));
 
-				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . TITANIA_TRACKER;
+				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . ext::TITANIA_TRACKER;
 			break;
 
 			case 'all_support' :
@@ -356,7 +358,7 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 				{
 					$mod_in_types = $types->find_authed('moderate');
 
-					$sql_ary['WHERE'] .= ' AND (' . phpbb::$db->sql_in_set('contrib.contrib_status', array(TITANIA_CONTRIB_APPROVED, TITANIA_CONTRIB_DOWNLOAD_DISABLED)) .
+					$sql_ary['WHERE'] .= ' AND (' . phpbb::$db->sql_in_set('contrib.contrib_status', array(ext::TITANIA_CONTRIB_APPROVED, ext::TITANIA_CONTRIB_DOWNLOAD_DISABLED)) .
 											(sizeof($mod_in_types) ? ' OR ' . phpbb::$db->sql_in_set('contrib.contrib_type', $mod_in_types) : '') . ')';
 				}
 
@@ -374,14 +376,14 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 				}
 
 				// Additional tracking field (to allow marking all support/discussion as read)
-				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . TITANIA_SUPPORT;
+				$sql_ary['WHERE'] .= ' AND t.topic_type = ' . ext::TITANIA_SUPPORT;
 
-				$tracking->get_track_sql($sql_ary, TITANIA_SUPPORT, 'contrib.contrib_id', 'tst');
-				$topic->additional_unread_fields[] = array('type' => TITANIA_SUPPORT, 'parent_match' => true);
+				$tracking->get_track_sql($sql_ary, ext::TITANIA_SUPPORT, 'contrib.contrib_id', 'tst');
+				$topic->additional_unread_fields[] = array('type' => ext::TITANIA_SUPPORT, 'parent_match' => true);
 
 				// Additional tracking for all support topics
-				$tracking->get_track_sql($sql_ary, TITANIA_ALL_SUPPORT, 0, 'tstg');
-				$topic->additional_unread_fields[] = array('type' => TITANIA_ALL_SUPPORT, 'id' => 0);
+				$tracking->get_track_sql($sql_ary, ext::TITANIA_ALL_SUPPORT, 0, 'tstg');
+				$topic->additional_unread_fields[] = array('type' => ext::TITANIA_ALL_SUPPORT, 'id' => 0);
 
 				// Do not order stickies first
 				$sql_ary['ORDER_BY'] = $sort->get_order_by();
@@ -396,26 +398,26 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 				// We also display the queue discussion topic between validators and authors in the support area
 				if ($object->is_author ||$object->is_active_coauthor || $object->type->acl_get('queue_discussion'))
 				{
-					$sql_ary['WHERE'] .= ' AND (t.topic_type = ' . TITANIA_SUPPORT . ' OR t.topic_type = ' . TITANIA_QUEUE_DISCUSSION . ')';
+					$sql_ary['WHERE'] .= ' AND (t.topic_type = ' . ext::TITANIA_SUPPORT . ' OR t.topic_type = ' . ext::TITANIA_QUEUE_DISCUSSION . ')';
 				}
 				else
 				{
-					$sql_ary['WHERE'] .= ' AND t.topic_type = ' . TITANIA_SUPPORT;
+					$sql_ary['WHERE'] .= ' AND t.topic_type = ' . ext::TITANIA_SUPPORT;
 				}
 
 				// Additional tracking for marking items as read in each contribution
-				$tracking->get_track_sql($sql_ary, TITANIA_SUPPORT, $object->contrib_id, 'tst');
-				$topic->additional_unread_fields[] = array('type' => TITANIA_SUPPORT, 'parent_match' => true);
+				$tracking->get_track_sql($sql_ary, ext::TITANIA_SUPPORT, $object->contrib_id, 'tst');
+				$topic->additional_unread_fields[] = array('type' => ext::TITANIA_SUPPORT, 'parent_match' => true);
 
 				// Additional tracking for all support topics
-				$tracking->get_track_sql($sql_ary, TITANIA_ALL_SUPPORT, 0, 'tstg');
-				$topic->additional_unread_fields[] = array('type' => TITANIA_ALL_SUPPORT, 'id' => 0);
+				$tracking->get_track_sql($sql_ary, ext::TITANIA_ALL_SUPPORT, 0, 'tstg');
+				$topic->additional_unread_fields[] = array('type' => ext::TITANIA_ALL_SUPPORT, 'id' => 0);
 
 				// Track the queue discussion too if applicable
 				if ($object->type->acl_get('queue_discussion'))
 				{
-					$tracking->get_track_sql($sql_ary, TITANIA_QUEUE_DISCUSSION, 0, 'tqt');
-					$topic->additional_unread_fields[] = array('type' => TITANIA_QUEUE_DISCUSSION, 'id' => 0, 'type_match' => true);
+					$tracking->get_track_sql($sql_ary, ext::TITANIA_QUEUE_DISCUSSION, 0, 'tqt');
+					$topic->additional_unread_fields[] = array('type' => ext::TITANIA_QUEUE_DISCUSSION, 'id' => 0, 'type_match' => true);
 				}
 			break;
 		}

--- a/manage/tool/composer/rebuild_repo.php
+++ b/manage/tool/composer/rebuild_repo.php
@@ -20,6 +20,7 @@ use phpbb\titania\config\config as ext_config;
 use phpbb\titania\contribution\type\collection as type_collection;
 use phpbb\titania\controller\helper;
 use phpbb\titania\entity\package;
+use phpbb\titania\ext;
 use phpbb\titania\manage\tool\base;
 use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Finder\SplFileInfo;
@@ -106,8 +107,8 @@ class rebuild_repo extends base
 				FROM ' . $this->contribs_table . ' c, ' .
 				$this->revisions_table . ' r
 				WHERE c.contrib_id = r.contrib_id
-					AND c.contrib_status = ' . TITANIA_CONTRIB_APPROVED . '
-					AND r.revision_status = ' . TITANIA_REVISION_APPROVED . '
+					AND c.contrib_status = ' . ext::TITANIA_CONTRIB_APPROVED . '
+					AND r.revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
 					AND ' . $this->db->sql_in_set('c.contrib_type', $types);
 			$this->db->sql_query($sql);
 			$this->total = (int) $this->db->sql_fetchfield('cnt');
@@ -145,8 +146,8 @@ class rebuild_repo extends base
 			$attach_table . '
 			WHERE c.contrib_id = r.contrib_id ' .
 			$attach_where . '
-				AND c.contrib_status = ' . TITANIA_CONTRIB_APPROVED . '
-				AND r.revision_status = ' . TITANIA_REVISION_APPROVED . '
+				AND c.contrib_status = ' . ext::TITANIA_CONTRIB_APPROVED . '
+				AND r.revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
 				AND ' . $this->db->sql_in_set('c.contrib_type', $types) . '
 			ORDER BY c.contrib_id ASC, r.revision_id ASC';
 		$result = $this->db->sql_query_limit($sql, $this->limit, $this->start);

--- a/manage/tool/contribution/resync_count.php
+++ b/manage/tool/contribution/resync_count.php
@@ -14,9 +14,9 @@
 namespace phpbb\titania\manage\tool\contribution;
 
 use phpbb\db\driver\driver_interface as db_driver_interface;
-use phpbb\request\request_interface;
 use phpbb\titania\config\config as ext_config;
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use phpbb\titania\manage\tool\base;
 use phpbb\user;
 use Symfony\Component\Console\Helper\ProgressHelper;
@@ -46,8 +46,8 @@ class resync_count extends base
 
 	/** @var array */
 	protected $valid_statuses = array(
-		TITANIA_CONTRIB_APPROVED,
-		TITANIA_CONTRIB_DOWNLOAD_DISABLED,
+		ext::TITANIA_CONTRIB_APPROVED,
+		ext::TITANIA_CONTRIB_DOWNLOAD_DISABLED,
 	);
 
 	/**

--- a/manage/tool/contribution/update_release_topics.php
+++ b/manage/tool/contribution/update_release_topics.php
@@ -14,9 +14,9 @@
 namespace phpbb\titania\manage\tool\contribution;
 
 use phpbb\db\driver\driver_interface as db_driver_interface;
-use phpbb\request\request_interface;
 use phpbb\titania\config\config as ext_config;
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use phpbb\titania\manage\tool\base;
 use phpbb\titania\versions;
 use phpbb\user;
@@ -88,8 +88,8 @@ class update_release_topics extends base
 				$sql = 'SELECT COUNT(contrib_id) AS cnt
 					FROM ' . $this->contribs_table . '
 					WHERE ' . $this->db->sql_in_set('contrib_status', array(
-							TITANIA_CONTRIB_APPROVED,
-							TITANIA_CONTRIB_DOWNLOAD_DISABLED,
+							ext::TITANIA_CONTRIB_APPROVED,
+							ext::TITANIA_CONTRIB_DOWNLOAD_DISABLED,
 						)) . '
 						AND ' . $this->db->sql_in_set('contrib_type', $types);
 				$result = $this->db->sql_query($sql);
@@ -134,8 +134,8 @@ class update_release_topics extends base
 			'GROUP_BY'	=> 'c.contrib_id',
 
 			'WHERE'		=> $this->db->sql_in_set('c.contrib_status', array(
-					TITANIA_CONTRIB_APPROVED,
-					TITANIA_CONTRIB_DOWNLOAD_DISABLED,
+					ext::TITANIA_CONTRIB_APPROVED,
+					ext::TITANIA_CONTRIB_DOWNLOAD_DISABLED,
 				)) . '
 				AND u.user_id = c.contrib_user_id
 				AND ' . $this->db->sql_in_set('contrib_type', $types),

--- a/manage/tool/topic/rebuild_urls.php
+++ b/manage/tool/topic/rebuild_urls.php
@@ -17,6 +17,7 @@ namespace phpbb\titania\manage\tool\topic;
 use phpbb\db\driver\driver_interface as db_driver_interface;
 use phpbb\titania\config\config as ext_config;
 use phpbb\titania\contribution\type\collection as type_collection;
+use phpbb\titania\ext;
 use phpbb\titania\manage\tool\base;
 use phpbb\user;
 use Symfony\Component\Console\Helper\ProgressHelper;
@@ -190,7 +191,7 @@ class rebuild_urls extends base
 		$i = 0;
 
 		$topic_type_where = $this->db->sql_in_set('topic_type',
-			array(TITANIA_SUPPORT, TITANIA_QUEUE_DISCUSSION)
+			array(ext::TITANIA_SUPPORT, ext::TITANIA_QUEUE_DISCUSSION)
 		);
 
 		$sql = 'SELECT contrib_id, contrib_type, contrib_name_clean

--- a/message/message.php
+++ b/message/message.php
@@ -15,6 +15,7 @@ namespace phpbb\titania\message;
 
 use phpbb\request\request_interface;
 use phpbb\titania\access;
+use phpbb\titania\ext;
 
 class message
 {
@@ -382,7 +383,7 @@ class message
 
 		$qr_hidden_fields = array();
 
-		if ($this->user->data['user_notify'] && $this->post_object->topic_type == TITANIA_SUPPORT)
+		if ($this->user->data['user_notify'] && $this->post_object->topic_type == ext::TITANIA_SUPPORT)
 		{
 			$qr_hidden_fields['notify'] = true;
 		}

--- a/migrations/base.php
+++ b/migrations/base.php
@@ -13,8 +13,6 @@
 
 namespace phpbb\titania\migrations;
 
-use phpbb\db\migration\exception;
-
 class base extends \phpbb\db\migration\migration
 {
 	/** @var \phpbb\titania\config\config */

--- a/migrations/release_1_1_0.php
+++ b/migrations/release_1_1_0.php
@@ -13,6 +13,8 @@
 
 namespace phpbb\titania\migrations;
 
+use phpbb\titania\ext;
+
 class release_1_1_0 extends base
 {
 	static public function depends_on()
@@ -673,7 +675,7 @@ class release_1_1_0 extends base
 
 		$tag_types = array(
 			array(
-				'tag_type_id'	=> TITANIA_QUEUE,
+				'tag_type_id'	=> ext::TITANIA_QUEUE,
 				'tag_type_name'	=> 'QUEUE_TAGS',
 			)
 		);
@@ -683,7 +685,7 @@ class release_1_1_0 extends base
 		$tags = array(
 			array(
 				'tag_id'			=> 1,
-				'tag_type_id'		=> TITANIA_QUEUE,
+				'tag_type_id'		=> ext::TITANIA_QUEUE,
 				'tag_field_name'	=> 'QUEUE_NEW',
 				'tag_clean_name'	=> 'new',
 				'no_delete'			=> true,
@@ -691,42 +693,42 @@ class release_1_1_0 extends base
 			// Leave space for others if we need to hard-code any
 			array(
 				'tag_id'			=> 15,
-				'tag_type_id'		=> TITANIA_QUEUE,
+				'tag_type_id'		=> ext::TITANIA_QUEUE,
 				'tag_field_name'	=> 'QUEUE_ATTENTION',
 				'tag_clean_name'	=> 'attention',
 				'no_delete'			=> false,
 			),
 			array(
 				'tag_id'			=> 16,
-				'tag_type_id'		=> TITANIA_QUEUE,
+				'tag_type_id'		=> ext::TITANIA_QUEUE,
 				'tag_field_name'	=> 'QUEUE_REPACK',
 				'tag_clean_name'	=> 'repack',
 				'no_delete'			=> false,
 			),
 			array(
 				'tag_id'			=> 17,
-				'tag_type_id'		=> TITANIA_QUEUE,
+				'tag_type_id'		=> ext::TITANIA_QUEUE,
 				'tag_field_name'	=> 'QUEUE_VALIDATING',
 				'tag_clean_name'	=> 'validating',
 				'no_delete'			=> false,
 			),
 			array(
 				'tag_id'			=> 18,
-				'tag_type_id'		=> TITANIA_QUEUE,
+				'tag_type_id'		=> ext::TITANIA_QUEUE,
 				'tag_field_name'	=> 'QUEUE_TESTING',
 				'tag_clean_name'	=> 'testing',
 				'no_delete'			=> false,
 			),
 			array(
 				'tag_id'			=> 19,
-				'tag_type_id'		=> TITANIA_QUEUE,
+				'tag_type_id'		=> ext::TITANIA_QUEUE,
 				'tag_field_name'	=> 'QUEUE_APPROVE',
 				'tag_clean_name'	=> 'approve',
 				'no_delete'			=> false,
 			),
 			array(
 				'tag_id'			=> 20,
-				'tag_type_id'		=> TITANIA_QUEUE,
+				'tag_type_id'		=> ext::TITANIA_QUEUE,
 				'tag_field_name'	=> 'QUEUE_DENY',
 				'tag_clean_name'	=> 'deny',
 				'no_delete'			=> false,

--- a/migrations/update_url_field_values.php
+++ b/migrations/update_url_field_values.php
@@ -13,6 +13,8 @@
 
 namespace phpbb\titania\migrations;
 
+use phpbb\titania\ext;
+
 class update_url_field_values extends base
 {
 	static public function depends_on()
@@ -25,7 +27,6 @@ class update_url_field_values extends base
 		return array(
 			array('custom', array(array($this, 'update_post_url'))),
 			array('custom', array(array($this, 'update_topic_url'))),
-			
 		);
 	}
 
@@ -57,15 +58,15 @@ class update_url_field_values extends base
 
 			switch ($row[$field . '_type'])
 			{
-				case TITANIA_SUPPORT:
-				case TITANIA_QUEUE_DISCUSSION:
+				case ext::TITANIA_SUPPORT:
+				case ext::TITANIA_QUEUE_DISCUSSION:
 					$params = array(
 						'contrib_type'	=> $pieces[0],
 						'contrib'		=> $pieces[1],
 					);
 				break;
 
-				case TITANIA_QUEUE:
+				case ext::TITANIA_QUEUE:
 					$params = array(
 						'id'	=> (int) substr($url, strrpos($url, '_') + 1),
 					);

--- a/posting.php
+++ b/posting.php
@@ -15,9 +15,9 @@ namespace phpbb\titania;
 
 use phpbb\exception\http_exception;
 use phpbb\titania\message\message;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 class posting
 {
@@ -191,7 +191,7 @@ class posting
 		{
 			$is_author = $this->get_contrib($parent_id)->is_author();
 		}
-		if ($is_author && $post_type == TITANIA_QUEUE_DISCUSSION)
+		if ($is_author && $post_type == ext::TITANIA_QUEUE_DISCUSSION)
 		{
 			$post->topic->topic_category = $this->contrib->contrib_type;
 		}
@@ -199,7 +199,7 @@ class posting
 		// Load the message object
 		$this->setup_message($post,
 			array(
-				'sticky_topic'	=> $post_type == TITANIA_SUPPORT && ($is_moderator || $is_author),
+				'sticky_topic'	=> $post_type == ext::TITANIA_SUPPORT && ($is_moderator || $is_author),
 				'lock_topic'	=> $is_moderator || ($is_author && $can_moderate_own),
 			),
 			array(
@@ -497,7 +497,7 @@ class posting
 		$is_moderator = $this->auth->acl_get('u_titania_mod_post_mod');
 		$is_author = false;
 
-		if ($post->post_type == TITANIA_SUPPORT)
+		if ($post->post_type == ext::TITANIA_SUPPORT)
 		{
 			$is_author = $this->get_contrib($post->topic->parent_id)->is_author();
 		}
@@ -694,7 +694,7 @@ class posting
 		$topic = $this->load_topic($topic_id);
 		$errors = array();
 
-		if ($topic->topic_type != TITANIA_SUPPORT)
+		if ($topic->topic_type != ext::TITANIA_SUPPORT)
 		{
 			return $this->controller_helper->message('SPLIT_NOT_ALLOWED');
 		}
@@ -742,7 +742,7 @@ class posting
 					}
 
 					// Only allow support posts to be moved to the same contrib
-					if ($new_topic->parent_id != $topic->parent_id || $new_topic->topic_type != TITANIA_SUPPORT)
+					if ($new_topic->parent_id != $topic->parent_id || $new_topic->topic_type != ext::TITANIA_SUPPORT)
 					{
 						$errors[] = $this->user->lang['ERROR_NOT_SAME_PARENT'];
 					}
@@ -757,7 +757,7 @@ class posting
 					// Get info from first post
 					$sql = 'SELECT post_id, post_access, post_approved, post_time
 						FROM ' . TITANIA_POSTS_TABLE . '
-						WHERE post_type = ' . TITANIA_SUPPORT . '
+						WHERE post_type = ' . ext::TITANIA_SUPPORT . '
 							AND topic_id = ' . (int) $topic->topic_id . '
 							AND ';
 					$result = $this->db->sql_query_limit($sql . $sql_extra, 1);
@@ -1030,13 +1030,13 @@ class posting
 			else
 			{
 				// Force Queue Discussion topics to always be stickies
-				if ($post->post_type == TITANIA_QUEUE_DISCUSSION)
+				if ($post->post_type == ext::TITANIA_QUEUE_DISCUSSION)
 				{
 					$post->topic->topic_sticky = true;
 				}
 
 				// Does the post need approval?  Never for the Queue Discussion or Queue. Do not set again in edit mode, otherwise this causes problems when the post has been approved.
-				if (!$this->auth->acl_get('u_titania_post_approved') && $post->post_type != TITANIA_QUEUE_DISCUSSION && $post->post_type != TITANIA_QUEUE && $mode != 'edit')
+				if (!$this->auth->acl_get('u_titania_post_approved') && $post->post_type != ext::TITANIA_QUEUE_DISCUSSION && $post->post_type != ext::TITANIA_QUEUE && $mode != 'edit')
 				{
 					$post->post_approved = false;
 				}
@@ -1050,7 +1050,7 @@ class posting
 				// Did they want to subscribe?
 				if ($this->request->is_set_post('notify') && $this->user->data['is_registered'])
 				{
-					$this->subscriptions->subscribe(TITANIA_TOPIC, $post->topic->topic_id);
+					$this->subscriptions->subscribe(ext::TITANIA_TOPIC, $post->topic->topic_id);
 				}
 
 				// Unapproved posts will get a notice
@@ -1094,12 +1094,12 @@ class posting
 		}
 
 		// Do we subscribe to actual topic?
-		$is_subscribed 	= $is_reply && $this->subscriptions->is_subscribed(TITANIA_TOPIC, $post->topic->topic_id);
+		$is_subscribed 	= $is_reply && $this->subscriptions->is_subscribed(ext::TITANIA_TOPIC, $post->topic->topic_id);
 		$can_subscribe = $this->user->data['is_registered'] && !$is_subscribed;
 
 		$this->template->assign_vars(array(
 			'S_NOTIFY_ALLOWED'	=> $can_subscribe,
-			'S_NOTIFY_CHECKED'	=> ($can_subscribe && $this->user->data['user_notify'] && $post->post_type == TITANIA_SUPPORT) ? ' checked=checked' : '',
+			'S_NOTIFY_CHECKED'	=> ($can_subscribe && $this->user->data['user_notify'] && $post->post_type == ext::TITANIA_SUPPORT) ? ' checked=checked' : '',
 		));
 
 		$topic_access_level = access::PUBLIC_LEVEL;
@@ -1246,7 +1246,7 @@ class posting
 	 */
 	protected function send_notifications(\titania_post $post, $mode)
 	{
-		$is_support_topic = $post->post_type == TITANIA_SUPPORT &&
+		$is_support_topic = $post->post_type == ext::TITANIA_SUPPORT &&
 			is_object($this->contrib) &&
 			$this->contrib->contrib_id == $post->topic->parent_id &&
 			$this->contrib->contrib_name
@@ -1265,7 +1265,7 @@ class posting
 
 		if ($mode == 'reply')
 		{
-			$object_type	= array(TITANIA_TOPIC);
+			$object_type	= array(ext::TITANIA_TOPIC);
 			$object_id		= array($post->topic_id);
 			$topic_params	= array(
 				'view'	=> 'unread',
@@ -1276,7 +1276,7 @@ class posting
 			{
 				// Support topic reply
 				$object_id[]	= $post->topic->parent_id;
-				$object_type[]	= TITANIA_SUPPORT;
+				$object_type[]	= ext::TITANIA_SUPPORT;
 				$template 		.= '_contrib';
 			}
 		}
@@ -1344,6 +1344,6 @@ class posting
 	 */
 	protected function is_topic_moderatable($type)
 	{
-		return in_array($type, array(TITANIA_QUEUE_DISCUSSION, TITANIA_SUPPORT));
+		return in_array($type, array(ext::TITANIA_QUEUE_DISCUSSION, ext::TITANIA_SUPPORT));
 	}
 }

--- a/queue/stats.php
+++ b/queue/stats.php
@@ -14,6 +14,7 @@
 namespace phpbb\titania\queue;
 
 use phpbb\titania\date;
+use phpbb\titania\ext;
 
 /**
  * Class to handle queue stats
@@ -94,7 +95,7 @@ class stats
 	 */
 	public function get_queue_item_count($included_statuses = false, $excluded_statuses = false)
 	{
-		$sql = 'SELECT COUNT(queue_id) AS status_count 
+		$sql = 'SELECT COUNT(queue_id) AS status_count
 			FROM ' . TITANIA_QUEUE_TABLE . '
 			WHERE queue_type = ' . $this->queue_type .
 			((!empty($included_statuses)) ? ' AND ' . $this->db->sql_in_set('queue_status', $included_statuses) : '') .
@@ -184,8 +185,8 @@ class stats
 		$sql = 'SELECT queue_status AS status, queue_submit_time AS submit_time, queue_close_time AS close_time
 			FROM ' . TITANIA_QUEUE_TABLE . '
 			WHERE queue_type = ' . $this->queue_type . '
-				AND ' . $this->db->sql_in_set('queue_status', array(TITANIA_QUEUE_CLOSED, TITANIA_QUEUE_HIDE), true) . '
-				AND ((queue_submit_time > ' . $start_time . ' AND queue_submit_time < ' . $end_time . ') 
+				AND ' . $this->db->sql_in_set('queue_status', array(ext::TITANIA_QUEUE_CLOSED, ext::TITANIA_QUEUE_HIDE), true) . '
+				AND ((queue_submit_time > ' . $start_time . ' AND queue_submit_time < ' . $end_time . ')
 					OR (queue_close_time > ' . $start_time . ' AND queue_close_time < ' . $end_time . '))';
 		$result = $this->db->sql_query($sql);
 
@@ -215,8 +216,8 @@ class stats
 			$this->add_history_action($history, 'new', $item['submit_time']);
 		}
 		$validated_status_map = array(
-			TITANIA_QUEUE_APPROVED	=> 'approved',
-			TITANIA_QUEUE_DENIED 	=> 'denied',
+			ext::TITANIA_QUEUE_APPROVED	=> 'approved',
+			ext::TITANIA_QUEUE_DENIED	=> 'denied',
 		);
 
 		if (isset($validated_status_map[$item['status']]) && $start_time <= $item['close_time'] && $end_time >= $item['close_time'])

--- a/search/driver/fulltext_sphinx.php
+++ b/search/driver/fulltext_sphinx.php
@@ -15,6 +15,7 @@ namespace phpbb\titania\search\driver;
 
 use phpbb\exception\http_exception;
 use phpbb\titania\access;
+use phpbb\titania\ext;
 
 class fulltext_sphinx extends base
 {
@@ -59,9 +60,9 @@ class fulltext_sphinx extends base
 
 	/** @var array */
 	protected $types = array(
-		TITANIA_CONTRIB		=> 'contrib',
-		TITANIA_FAQ			=> 'faq',
-		TITANIA_SUPPORT		=> 'post',
+		ext::TITANIA_CONTRIB		=> 'contrib',
+		ext::TITANIA_FAQ			=> 'faq',
+		ext::TITANIA_SUPPORT		=> 'post',
 	);
 
 	const MAX_MATCHES = 20000;
@@ -377,19 +378,19 @@ class fulltext_sphinx extends base
 				contrib_id AS real_id,
 				0 AS parent_id,
 				contrib_user_id AS author,' .
-				TITANIA_CONTRIB . ' AS type,' .
+				ext::TITANIA_CONTRIB . ' AS type,' .
 				access::PUBLIC_LEVEL . ' AS access_level,
 				CASE contrib_status
-					WHEN ' . TITANIA_CONTRIB_NEW . '
-						OR ' . TITANIA_CONTRIB_HIDDEN . '
-						OR ' . TITANIA_CONTRIB_DISABLED . '
+					WHEN ' . ext::TITANIA_CONTRIB_NEW . '
+						OR ' . ext::TITANIA_CONTRIB_HIDDEN . '
+						OR ' . ext::TITANIA_CONTRIB_DISABLED . '
 					THEN 0
 					ELSE 1
 				END AS approved,
 				contrib_last_update AS date,
 				contrib_name AS title,
 				contrib_desc AS data,
-				CONCAT("' . TITANIA_CONTRIB . '0", contrib_type) AS type_ptype
+				CONCAT("' . ext::TITANIA_CONTRIB . '0", contrib_type) AS type_ptype
 			FROM ' . $this->contribs_table . '
 			WHERE ';
 		$categories_sql = '
@@ -414,19 +415,19 @@ class fulltext_sphinx extends base
 				f.faq_id AS real_id,
 				f.contrib_id AS parent_id,
 				c.contrib_user_id AS author,' .
-				TITANIA_FAQ . ' AS type,
+				ext::TITANIA_FAQ . ' AS type,
 				f.faq_access AS access_level,
 				CASE c.contrib_status
-					WHEN (' . TITANIA_CONTRIB_NEW . '
-						OR ' . TITANIA_CONTRIB_HIDDEN . '
-						OR ' . TITANIA_CONTRIB_DISABLED . ')
+					WHEN (' . ext::TITANIA_CONTRIB_NEW . '
+						OR ' . ext::TITANIA_CONTRIB_HIDDEN . '
+						OR ' . ext::TITANIA_CONTRIB_DISABLED . ')
 					THEN 0
 					ELSE 1
 				END AS approved,
 				0 AS date,
 				f.faq_subject AS title,
 				f.faq_text AS data,
-				CONCAT("' . TITANIA_FAQ . '0", c.contrib_type) AS type_ptype
+				CONCAT("' . ext::TITANIA_FAQ . '0", c.contrib_type) AS type_ptype
 			FROM ' . $this->faq_table . ' f, ' . $this->contribs_table . ' c
 			WHERE f.contrib_id = c.contrib_id AND ';
 


### PR DESCRIPTION
All constants define()d in `includes/constants.php` were moved to class constants in `ext.php`. The `includes/constants.php` is still there with a `deprecated` message at the top.

I also reverted the commit from earlier (1ed3b21) as it still caused errors when deleting data.