### PR TITLE
Remove sid from download and announcement links in version_check files

### DIFF
--- a/controller/contribution/contribution.php
+++ b/controller/contribution/contribution.php
@@ -295,16 +295,18 @@ class contribution extends base
 				continue;
 			}
 
+			$empty_sid = '';
+
 			$branches[$matches[1]] = array(
 				'current'		=> $version,
 				'download'		=> $this->helper->route('phpbb.titania.download', array(
 					'id' => $download['attachment_id'],
-				)),
+				), true, $empty_sid),
 				'announcement'	=> $this->helper->route('phpbb.titania.contrib', array(
 					'page'			=> '',
 					'contrib_type'	=> $contrib_type,
 					'contrib'		=> $contrib,
-				)),
+				), true, $empty_sid),
 				'eol'			=> null,
 				'security'		=> false,
 			);


### PR DESCRIPTION
`$session_id` defaults to `false` which appends the global `$_SID` to download and announcement links. Passing an empty string instead will omit the sid entirely.