### PR TITLE
Use phpbb version branches as the branch keys

### DIFF
--- a/controller/contribution/contribution.php
+++ b/controller/contribution/contribution.php
@@ -286,18 +286,22 @@ class contribution extends base
 		$this->contrib->get_download();
 		$branches = array();
 
-		foreach ($this->contrib->download as $download)
+		ksort($this->contrib->download);
+
+		foreach ($this->contrib->download as $branch => $download)
 		{
 			$version = $download['revision_version'];
 
-			if (!preg_match('#^(\d+\.\d+)#', $version, $matches))
+			if (!preg_match('#^(\d+\.\d+)#', $version))
 			{
 				continue;
 			}
 
+			$branch = substr_replace($branch, '.', 1, 0);
+
 			$empty_sid = '';
 
-			$branches[$matches[1]] = array(
+			$branches[$branch] = array(
 				'current'		=> $version,
 				'download'		=> $this->helper->route('phpbb.titania.download', array(
 					'id' => $download['attachment_id'],


### PR DESCRIPTION
Updating so ext manager will be able to show users the correct update for their installed branch of phpbb.

This makes it so the phpBB version(s) the ext is validated for are used as the branch keys, e.g.:
```json
{
  "3.1": {
    "current": "1.0.5",
    "download": "https://www.phpbb.com/customise/db/download/1",
    "announcement": "https://www.phpbb.com/customise/db/extension/foo/",
    "eol": null,
    "security": false
  },
  "3.2": {
    "current": "2.0.1",
    "download": "https://www.phpbb.com/customise/db/download/2",
    "announcement": "https://www.phpbb.com/customise/db/extension/foo/",
    "eol": null,
    "security": false
  }
}
```
