### PR TITLE
Fix PHP7 issues with isset on $ext_config

### DIFF
--- a/attachment/plupload.php
+++ b/attachment/plupload.php
@@ -48,7 +48,7 @@ class plupload extends \phpbb\plupload\plupload
 	 */
 	public function generate_filter_string_ext($ext_config, $object_type)
 	{
-		if (!isset($ext_config->upload_allowed_extensions[$object_type]))
+		if ($ext_config->upload_allowed_extensions[$object_type] === null)
 		{
 			return '';
 		}

--- a/attachment/uploader.php
+++ b/attachment/uploader.php
@@ -224,7 +224,7 @@ class uploader
 	/**
 	 * Uploads a file to server
 	 *
-	 * @return array filedata
+	 * @return false|array filedata
 	 */
 	public function upload_file()
 	{
@@ -240,7 +240,7 @@ class uploader
 			return false;
 		}
 
-		if (!isset($this->ext_config->upload_allowed_extensions[$this->object_type]))
+		if ($this->ext_config->upload_allowed_extensions[$this->object_type] === null)
 		{
 			$this->filedata['error'][] = $this->user->lang['NO_UPLOAD_FORM_FOUND'];
 
@@ -269,7 +269,7 @@ class uploader
 		$file->clean_filename('unique', $this->user->data['user_id'] . '_');
 
 		// Move files into their own directory depending on the extension group assigned.  Should keep at least some of it organized.
-		if (!isset($this->ext_config->upload_directory[$this->object_type]))
+		if ($this->ext_config->upload_directory[$this->object_type] === null)
 		{
 			$this->filedata['error'][] = $this->user->lang('NO_UPLOAD_FORM_FOUND');
 
@@ -332,12 +332,9 @@ class uploader
 	public function parse_uploader($tpl_file = 'posting/attachments/default.html', $custom_sort = false)
 	{
 		// If the upload max filesize is less than 0, do not show the uploader (0 = unlimited)
-		if (!$this->access->is_team())
+		if (!$this->access->is_team() && $this->ext_config->upload_max_filesize[$this->object_type] !== null && $this->ext_config->upload_max_filesize[$this->object_type] < 0)
 		{
-			if (isset($this->ext_config->upload_max_filesize[$this->object_type]) && $this->ext_config->upload_max_filesize[$this->object_type] < 0)
-			{
-				return '';
-			}
+			return '';
 		}
 
 		$this->template->assign_vars(array(
@@ -614,14 +611,12 @@ class uploader
 	 */
 	protected function get_max_filesize()
 	{
-		if (isset($this->ext_config->upload_max_filesize[$this->object_type]))
+		if ($this->ext_config->upload_max_filesize[$this->object_type] !== null)
 		{
 			return $this->ext_config->upload_max_filesize[$this->object_type];
 		}
-		else
-		{
-			return $this->config['max_filesize'];
-		}
+
+		return $this->config['max_filesize'];
 	}
 
 	/**

--- a/controller/index.php
+++ b/controller/index.php
@@ -638,7 +638,7 @@ class index
 	{
 		$_branch = (int) str_replace('.', '', $branch);
 
-		if ($branch != '' && !isset($this->ext_config->phpbb_versions[$_branch]))
+		if ($branch != '' && $this->ext_config->phpbb_versions[$_branch] === null)
 		{
 			throw new http_exception(404, 'NO_PAGE_FOUND');
 		}

--- a/includes/objects/revision.php
+++ b/includes/objects/revision.php
@@ -346,7 +346,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 					$row = array('phpbb_version_branch' => (int) $row);
 				}
 
-				if (!isset($row['phpbb_version_branch']) || !isset(titania::$config->phpbb_versions[$row['phpbb_version_branch']]))
+				if (!isset($row['phpbb_version_branch']) || titania::$config->phpbb_versions[$row['phpbb_version_branch']] === null)
 				{
 					continue;
 				}


### PR DESCRIPTION
https://tracker.phpbb.com/browse/CUSTDB-732

Using `isset` on the `$ext_config` object returns the wrong boolean result in PHP 7. I do not understand why, it may have to do with all the magic used to access the data in $ext_config. Maybe there's a better way, I don't know but in the mean time, replacing asset with a comparison against null also solves the issue in PHP 7.

Specifically these changes fix the problems where uploading a new contribution or revision fails under PHP 7.