### PR TITLE
Allow download button to grow in height if needed

### DIFF
--- a/styles/prosilver/theme/common.css
+++ b/styles/prosilver/theme/common.css
@@ -71,7 +71,7 @@ a.download-button, a.colorizeit-button {
 	color: #FFFFFF;
 	display: inline-block;
 	float: left;
-	height: 36px;
+	min-height: 36px;
 	font-weight: bold;
 	text-decoration: none;
 }


### PR DESCRIPTION
Turns this malarkey:
![screen shot 2017-05-29 at 5 45 35 pm](https://cloud.githubusercontent.com/assets/303711/26564527/c0e7d0c2-4496-11e7-9430-61d27472b72c.png)

Into this:
![screen shot 2017-05-29 at 5 45 52 pm](https://cloud.githubusercontent.com/assets/303711/26564530/c50a5404-4496-11e7-86b2-09d744d38042.png)
