### PR TITLE
Fix warning when sorting versions

### DIFF
--- a/cache/service.php
+++ b/cache/service.php
@@ -87,7 +87,7 @@ class service extends \phpbb\cache\service
 			$this->driver->put('_titania_phpbb_versions', $versions);
 		}
 
-		uasort($versions, array('versions', 'reverse_version_compare'));
+		uasort($versions, array(versions::class, 'reverse_version_compare'));
 
 		return $versions;
 	}


### PR DESCRIPTION
Namespaced static methods must be fully qualified if passed as string. I've used the `::class` approach as it's shorter.

https://tracker.phpbb.com/browse/CUSTDB-755