### PR TITLE
Fix issues with outdated titania routes

### DIFF
--- a/config/routes/contribution.yml
+++ b/config/routes/contribution.yml
@@ -1,82 +1,82 @@
 phpbb.titania.contrib:
-    pattern: /{page}
+    path: /{page}
     defaults: { _controller: phpbb.titania.controller.contrib:base, page: details }
     requirements:
         page: |details|report|queue_discussion|rate
 
 phpbb.titania.contrib.support:
-    pattern: /support
+    path: /support
     defaults: { _controller: phpbb.titania.controller.contrib.support:display_support }
 
 phpbb.titania.contrib.support.post_topic:
-    pattern: /support/new
+    path: /support/new
     defaults: { _controller: phpbb.titania.controller.contrib.support:topic_action, topic_id: 0, action: post }
 
 phpbb.titania.contrib.support.topic:
-    pattern: /support/topic/{topic_id}
+    path: /support/topic/{topic_id}
     defaults: { _controller: phpbb.titania.controller.contrib.support:display_topic }
     requirements:
         topic_id: \d+
 
 phpbb.titania.contrib.support.topic.action:
-    pattern: /support/topic/{topic_id}/{action}
+    path: /support/topic/{topic_id}/{action}
     defaults: { _controller: phpbb.titania.controller.contrib.support:topic_action }
     requirements:
         topic_id: \d+
 
 phpbb.titania.contrib.faq:
-    pattern: /faq
+    path: /faq
     defaults: { _controller: phpbb.titania.controller.contrib.faq:display_list}
 
 phpbb.titania.contrib.faq.create:
-    pattern: /faq/new
-    defaults: { _controller: phpbb.titania.controller.contrib.faq:item_action, action: 'create', id: 0 }
+    path: /faq/new
+    defaults: { _controller: phpbb.titania.controller.contrib.faq:item_action, action: create, id: 0 }
 
 phpbb.titania.contrib.faq.item:
-    pattern: /faq/{id}
+    path: /faq/{id}
     defaults: { _controller: phpbb.titania.controller.contrib.faq:display_item }
     requirements:
         id: \d+
 
 phpbb.titania.contrib.faq.item.action:
-    pattern: /faq/{id}/{action}
+    path: /faq/{id}/{action}
     defaults: { _controller: phpbb.titania.controller.contrib.faq:item_action }
     requirements:
         id: \d+
         page: edit|delete|move_up|move_down
 
 phpbb.titania.contrib.manage:
-    pattern: /manage
+    path: /manage
     defaults: { _controller: phpbb.titania.controller.contrib.manage:manage }
 
 phpbb.titania.contrib.manage.demo:
-    pattern: /manage/demo/{action}
+    path: /manage/demo/{action}
     defaults: { _controller: phpbb.titania.controller.contrib.manage:manage_demo }
     requirements:
         action: install|delete
 
 phpbb.titania.contrib.revision:
-    pattern: /revision
+    path: /revision
     defaults: { _controller: phpbb.titania.controller.contrib.revision:add }
 
 phpbb.titania.contrib.revision.repack:
-    pattern: /revision/{id}/repack
+    path: /revision/{id}/repack
     defaults: { _controller: phpbb.titania.controller.contrib.revision:repack }
     requirements:
         id: \d+
 
 phpbb.titania.contrib.revision.edit:
-    pattern: /revision/{id}/edit
+    path: /revision/{id}/edit
     defaults: { _controller: phpbb.titania.controller.contrib.revision.edit:edit }
     requirements:
         id: \d+
 
 phpbb.titania.contrib.demo:
-    pattern: /demo/{branch}
+    path: /demo/{branch}
     defaults: { _controller: phpbb.titania.controller.contrib:demo }
     requirements:
         branch: \d\.\d
 
 phpbb.titania.contrib.version_check:
-    pattern: /version_check
+    path: /version_check
     defaults: { _controller: phpbb.titania.controller.contrib:version_check }

--- a/config/routes/contribution.yml
+++ b/config/routes/contribution.yml
@@ -2,7 +2,7 @@ phpbb.titania.contrib:
     path: /{page}
     defaults: { _controller: phpbb.titania.controller.contrib:base, page: details }
     requirements:
-        page: |details|report|queue_discussion|rate
+        page: details|report|queue_discussion|rate|
 
 phpbb.titania.contrib.support:
     path: /support

--- a/config/routes/contribution.yml
+++ b/config/routes/contribution.yml
@@ -2,7 +2,7 @@ phpbb.titania.contrib:
     path: /{page}
     defaults: { _controller: phpbb.titania.controller.contrib:base, page: details }
     requirements:
-        page: details|report|queue_discussion|rate|
+        page: '|details|report|queue_discussion|rate'
 
 phpbb.titania.contrib.support:
     path: /support

--- a/config/routes/general.yml
+++ b/config/routes/general.yml
@@ -1,61 +1,61 @@
 phpbb.titania.index:
-    pattern: /
+    path: /
     defaults: { _controller: phpbb.titania.controller.index:display_index, branch: '' }
 
 phpbb.titania.index.branch:
-    pattern: /{branch}
+    path: /{branch}
     defaults: { _controller: phpbb.titania.controller.index:display_index, branch: '' }
     requirements:
         branch: \d\.\d|
 
 phpbb.titania.faq:
-    pattern: /faq
+    path: /faq
     defaults: { _controller: phpbb.titania.controller.faq:handle }
 
 phpbb.titania.queue_stats:
-    pattern: /queue-stats/{contrib_type}
+    path: /queue-stats/{contrib_type}
     defaults: { _controller: phpbb.titania.controller.queue_stats:display_stats }
 
 phpbb.titania.support:
-    pattern: /support/{type}
+    path: /support/{type}
     defaults: { _controller: phpbb.titania.controller.support:display_topics, type: all }
 
 phpbb.titania.author:
-    pattern: /author/{author}/{page}
+    path: /author/{author}/{page}
     defaults: { _controller: phpbb.titania.controller.author:base, page: details }
     requirements:
         page: |details|contributions|support|discussion|manage|create
 
 phpbb.titania.download:
-    pattern: /download/{id}/{type}
-    defaults: { _controller: phpbb.titania.controller.download:file, id: 0, type: 'manual' }
+    path: /download/{id}/{type}
+    defaults: { _controller: phpbb.titania.controller.download:file, id: 0, type: manual }
     requirements:
         id: \d+
 
 phpbb.titania.search:
-    pattern: /search
+    path: /search
     defaults: { _controller: phpbb.titania.controller.search:general }
 
 phpbb.titania.search.results:
-    pattern: /search/results
+    path: /search/results
     defaults: { _controller: phpbb.titania.controller.search:general_results }
 
 phpbb.titania.search.contributions:
-    pattern: /find-contribution
+    path: /find-contribution
     defaults: { _controller: phpbb.titania.controller.search:contributions }
 
 phpbb.titania.search.contributions.results:
-    pattern: /find-contribution/results
+    path: /find-contribution/results
     defaults: { _controller: phpbb.titania.controller.search:contribution_results }
 
 phpbb.titania.colorizeit:
-    pattern: /colorizeit/{id}
+    path: /colorizeit/{id}
     defaults: { _controller: phpbb.titania.controller.colorizeit:colorizeit_data }
     requirements:
         id: \d+
 
 phpbb.titania.contribution.id:
-    pattern: /contribution/id/{id}/
+    path: /contribution/id/{id}/
     defaults: { _controller: phpbb.titania.controller.contrib:redirect_from_id }
     requirements:
         id: \d+
@@ -65,11 +65,11 @@ phpbb.titania.composer:
     defaults: { _controller: phpbb.titania.controller.composer:serve_file }
 
 phpbb.titania.category:
-    pattern: /{category1}/{category2}/{category3}/{category4}
+    path: /{category1}/{category2}/{category3}/{category4}
     defaults: { _controller: phpbb.titania.controller.index:display_category, category2: '', category3: '', category4: '' }
 
 phpbb.titania.legacy:
-    pattern: /{path}
+    path: /{path}
     defaults: { _controller: phpbb.titania.controller.legacy_rerouter:redirect }
     requirements:
         path: .*

--- a/config/routes/general.yml
+++ b/config/routes/general.yml
@@ -24,7 +24,7 @@ phpbb.titania.author:
     path: /author/{author}/{page}
     defaults: { _controller: phpbb.titania.controller.author:base, page: details }
     requirements:
-        page: |details|contributions|support|discussion|manage|create
+        page: details|contributions|support|discussion|manage|create|
 
 phpbb.titania.download:
     path: /download/{id}/{type}

--- a/config/routes/general.yml
+++ b/config/routes/general.yml
@@ -24,7 +24,7 @@ phpbb.titania.author:
     path: /author/{author}/{page}
     defaults: { _controller: phpbb.titania.controller.author:base, page: details }
     requirements:
-        page: details|contributions|support|discussion|manage|create|
+        page: '|details|contributions|support|discussion|manage|create'
 
 phpbb.titania.download:
     path: /download/{id}/{type}

--- a/config/routes/manage.yml
+++ b/config/routes/manage.yml
@@ -1,103 +1,103 @@
 phpbb.titania.manage:
-    pattern: /
+    path: /
     defaults: { _controller: phpbb.titania.controller.manage:base }
 
 phpbb.titania.queue:
-    pattern: /queue
+    path: /queue
     defaults: { _controller: phpbb.titania.controller.manage.queue:list_queues }
 
 phpbb.titania.queue.type:
-    pattern: /queue/{queue_type}
+    path: /queue/{queue_type}
     defaults: { _controller: phpbb.titania.controller.manage.queue:display_queue }
     requirements:
         queue_type: mod|extension|style|converter|official_tool|bbcode|bridge|translation
 
 phpbb.titania.queue.item:
-    pattern: /queue/item/{id}
+    path: /queue/item/{id}
     defaults: { _controller: phpbb.titania.controller.manage.queue.item:display_item }
     requirements:
         id: \d+
 
 phpbb.titania.queue.item.action:
-    pattern: /queue/item/{id}/{action}
+    path: /queue/item/{id}/{action}
     defaults: { _controller: phpbb.titania.controller.manage.queue.item:item_action }
     requirements:
         id: \d+
 
 phpbb.titania.queue.tools:
-    pattern:  /queue/tools/{tool}/{id}
+    path:  /queue/tools/{tool}/{id}
     defaults: { _controller: phpbb.titania.controller.manage.queue.tools:run_tool }
     requirements:
         id: \d+
 
 phpbb.titania.manage.attention:
-    pattern: /attention
+    path: /attention
     defaults: { _controller: phpbb.titania.controller.manage.attention:display_list }
 
 phpbb.titania.manage.attention.redirect:
-    pattern: /attention/redirect
+    path: /attention/redirect
     defaults: { _controller: phpbb.titania.controller.manage.attention:redirect_to_item }
 
 phpbb.titania.manage.attention.item:
-    pattern: /attention/item/{id}
+    path: /attention/item/{id}
     defaults: { _controller: phpbb.titania.controller.manage.attention:display_item }
     requirements:
         id: \d+
 
 phpbb.titania.manage.attention.item.action:
-    pattern: /attention/item/{id}/{action}
+    path: /attention/item/{id}/{action}
     defaults: { _controller: phpbb.titania.controller.manage.attention:item_action }
     requirements:
         id: \d+
         action: approve|disapprove|close|delete
 
 phpbb.titania.manage.categories:
-    pattern: /categories/{id}
+    path: /categories/{id}
     defaults: { _controller: phpbb.titania.controller.manage.categories:list_categories, id: 0 }
     requirements:
         id: \d+
 
 phpbb.titania.manage.categories.action:
-    pattern: /categories/{id}/{action}
+    path: /categories/{id}/{action}
     defaults: { _controller: phpbb.titania.controller.manage.categories:category_action, id: 0 }
     requirements:
         id: \d+
         action: add|edit|delete|move_up|move_down
 
 phpbb.titania.queue_discussion:
-    pattern: /queue_discussion
+    path: /queue_discussion
     defaults: { _controller: phpbb.titania.controller.manage.queue_discussion:list_types }
 
 phpbb.titania.queue_discussion.type:
-    pattern: /queue_discussion/{queue_type}
+    path: /queue_discussion/{queue_type}
     defaults: { _controller: phpbb.titania.controller.manage.queue_discussion:display_type }
     requirements:
         queue_type: mod|extension|style|converter|official_tool|bbcode|bridge|translation
 
 phpbb.titania.administration:
-    pattern: /administration
+    path: /administration
     defaults: { _controller: phpbb.titania.controller.manage.administration:list_tools }
 
 phpbb.titania.manage.composer.rebuild_repo:
-    pattern: /administration/composer/rebuild_repo
+    path: /administration/composer/rebuild_repo
     defaults: { _controller: phpbb.titania.controller.manage.composer.rebuild_repo:handle }
 
 phpbb.titania.manage.contrib.resync_count:
-    pattern: /administration/contrib/resync_count
+    path: /administration/contrib/resync_count
     defaults: { _controller: phpbb.titania.controller.manage.contrib.resync_count:handle }
 
 phpbb.titania.manage.contrib.update_release_topics:
-    pattern: /administration/contrib/update_release_topics
+    path: /administration/contrib/update_release_topics
     defaults: { _controller: phpbb.titania.controller.manage.contrib.update_release_topics:handle }
 
 phpbb.titania.manage.search.reindex:
-    pattern: /administration/search/reindex
+    path: /administration/search/reindex
     defaults: { _controller: phpbb.titania.controller.manage.search.reindex:handle }
 
 phpbb.titania.manage.topic.rebuild_urls:
-    pattern: /administration/topic/rebuild_urls
+    path: /administration/topic/rebuild_urls
     defaults: { _controller: phpbb.titania.controller.manage.topic.rebuild_urls:handle }
 
 phpbb.titania.manage.topic.resync_dots:
-    pattern: /administration/topic/resync_dots
+    path: /administration/topic/resync_dots
     defaults: { _controller: phpbb.titania.controller.manage.topic.resync_dots:handle }


### PR DESCRIPTION
Note EPV can not be updated until after this PR is merged. When EPV is updated it will install Symfony 3 components that will break things because of the deprecated YAML code that this PR fixes.