### PR TITLE
Force package type to phpbb-extension

### DIFF
--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -240,6 +240,7 @@ class type extends base
 		}
 
 		$ext_name = $data['name'];
+		$data['type'] = 'phpbb-extension';
 		$data = $this->update_phpbb_requirement($data);
 		$data = $this->set_version_check($data, $contrib);
 


### PR DESCRIPTION
To make composer/installers work, the type has to be `phpbb-extension`.