### PR TITLE
Repack diff

### DIFF
--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -13,6 +13,8 @@
 
 namespace phpbb\titania\event;
 
+use phpbb\event\data;
+use s9e\TextFormatter\Configurator\Items\TemplateDocument;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -61,9 +63,10 @@ class main_listener implements EventSubscriberInterface
 	static public function getSubscribedEvents()
 	{
 		return array(
-			'core.permissions'			=> 'add_permissions',
-			'kernel.request'			=> array(array('startup', -1)),
-			'core.page_header_after'	=> 'overwrite_template_vars',
+			'core.permissions'							=> 'add_permissions',
+			'kernel.request'							=> array(array('startup', -1)),
+			'core.page_header_after'					=> 'overwrite_template_vars',
+            'core.text_formatter_s9e_configure_after'	=> 'inject_bbcode_code_lang',
 		);
 	}
 
@@ -125,7 +128,7 @@ class main_listener implements EventSubscriberInterface
 			'u_titania_mod_bbcode_queue'			=> array('lang' => 'ACL_U_TITANIA_MOD_BBCODE_QUEUE', 'cat' => 'titania_moderate'),
 			'u_titania_mod_bbcode_validate'			=> array('lang' => 'ACL_U_TITANIA_MOD_BBCODE_VALIDATE', 'cat' => 'titania_moderate'),
 			'u_titania_mod_bbcode_moderate'			=> array('lang' => 'ACL_U_TITANIA_MOD_BBCODE_MODERATE', 'cat' => 'titania_moderate'),
-	
+
 			'u_titania_mod_bridge_queue_discussion'	=> array('lang' => 'ACL_U_TITANIA_MOD_BRIDGE_QUEUE_DISCUSSION', 'cat' => 'titania_moderate'),
 			'u_titania_mod_bridge_queue'			=> array('lang' => 'ACL_U_TITANIA_MOD_BRIDGE_QUEUE', 'cat' => 'titania_moderate'),
 			'u_titania_mod_bridge_validate'			=> array('lang' => 'ACL_U_TITANIA_MOD_BRIDGE_VALIDATE', 'cat' => 'titania_moderate'),
@@ -193,4 +196,26 @@ class main_listener implements EventSubscriberInterface
 			));
 		}
 	}
+
+    /**
+     * Reads the value for the lang attribute passed to each code BBCode, e.g. [code=diff] or [code lang=diff],
+     * and adds it as a class attribute to the code element, e.g. <code class="diff">
+     *
+     * @param data $event
+     */
+    public function inject_bbcode_code_lang(data $event)
+    {
+        $tag = $event['configurator']->tags['CODE'];
+
+        /** @var TemplateDocument $dom */
+        $dom = $tag->template->asDOM();
+
+        foreach ($dom->getElementsByTagName('code') as $code)
+        {
+        	/** @var \DOMElement $code */
+			$code->setAttribute('class', '{@lang}');
+		}
+
+        $dom->saveChanges();
+    }
 }

--- a/includes/core/phpbb.php
+++ b/includes/core/phpbb.php
@@ -11,6 +11,16 @@
 *
 */
 
+use phpbb\auth\auth;
+use phpbb\cache\service as cache;
+use phpbb\config\config;
+use phpbb\db\driver\driver as db;
+use phpbb\event\dispatcher;
+use phpbb\request\request;
+use phpbb\template\template;
+use phpbb\user;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
 /**
  * phpBB class that will be used in place of globalising these variables.
  */
@@ -37,10 +47,10 @@ class phpbb
 	/** @var request phpBB request class */
 	public static $request;
 
-	/** @var object phpBB container */
+	/** @var ContainerBuilder phpBB container */
 	public static $container;
 
-	/* @var \phpbb\event\dispatcher */
+	/* @var dispatcher */
 	public static $dispatcher;
 
 	/** @var string */
@@ -95,8 +105,9 @@ class phpbb
 	* @param string $file The name of the file
 	* @param string|bool $function_check Bool false to ignore; string function name to check if the function exists (and not load the file if it does)
 	* @param string|bool $class_check Bool false to ignore; string class name to check if the class exists (and not load the file if it does)
+	* @param bool $class_auto_load Whether or not to attempt to auto-load the class given in $class_check
 	*/
-	public static function _include($file, $function_check = false, $class_check = false)
+	public static function _include($file, $function_check = false, $class_check = false, $class_auto_load = true)
 	{
 		if ($function_check !== false)
 		{
@@ -108,7 +119,7 @@ class phpbb
 
 		if ($class_check !== false)
 		{
-			if (class_exists($class_check))
+			if (class_exists($class_check, $class_auto_load))
 			{
 				return;
 			}

--- a/includes/objects/revision.php
+++ b/includes/objects/revision.php
@@ -544,7 +544,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 
 		if ($diff !== false)
 		{
-			$repack_message .= '[quote=&quot;' . $this->user->lang('VALIDATION_DIFF') . '&quot;][code lang=diff]' . $diff . "[/code][/quote]\n";
+			$repack_message .= '[quote=&quot;' . $this->user->lang('VALIDATION_REPACK_DIFF') . '&quot;][code lang=diff]' . $diff . "[/code][/quote]\n";
 		}
 
 		// Reply

--- a/includes/objects/revision.php
+++ b/includes/objects/revision.php
@@ -91,10 +91,10 @@ class titania_revision extends \phpbb\titania\entity\database_base
 			'revision_submitted'		=> array('default' => false), // False if it is still in the process of being submitted/verified; True if submission has finished
 			'revision_queue_id'			=> array('default' => 0),
 			'revision_license'			=> array('default' => ''),
-			'revision_clr_options'  	=> array('default' => ''),
-			'revision_bbc_html_replace' => array('default' => ''),
-			'revision_bbc_help_line' 	=> array('default' => ''),
-			'revision_bbc_bbcode_usage' => array('default' => ''),
+			'revision_clr_options'		=> array('default' => ''),
+			'revision_bbc_html_replace'	=> array('default' => ''),
+			'revision_bbc_help_line'	=> array('default' => ''),
+			'revision_bbc_bbcode_usage'	=> array('default' => ''),
 			'revision_bbc_demo'			=> array('default' => ''),
 			'revision_composer_json'	=> array('default' => ''),
 		));
@@ -231,12 +231,12 @@ class titania_revision extends \phpbb\titania\entity\database_base
 			}
 		}
 
-        // ColorizeIt stuff
-        $url_colorizeit = '';
-        if($this->revision_status == ext::TITANIA_REVISION_APPROVED && strlen(titania::$config->colorizeit) && $this->contrib && $this->contrib->has_colorizeit())
-        {
-            $url_colorizeit = 'http://' . titania::$config->colorizeit_url . '/custom/' . titania::$config->colorizeit . '.html?id=' . $this->attachment_id . '&amp;sample=' . $this->contrib->clr_sample->get_id();
-        }
+		// ColorizeIt stuff
+		$url_colorizeit = '';
+		if($this->revision_status == ext::TITANIA_REVISION_APPROVED && strlen(titania::$config->colorizeit) && $this->contrib && $this->contrib->has_colorizeit())
+		{
+			$url_colorizeit = 'http://' . titania::$config->colorizeit_url . '/custom/' . titania::$config->colorizeit . '.html?id=' . $this->attachment_id . '&amp;sample=' . $this->contrib->clr_sample->get_id();
+		}
 
 		phpbb::$template->assign_block_vars($tpl_block, array(
 			'REVISION_ID'			=> $this->revision_id,
@@ -255,9 +255,9 @@ class titania_revision extends \phpbb\titania\entity\database_base
 			'INSTALL_LEVEL'			=> ($this->install_level > 0) ? phpbb::$user->lang['INSTALL_LEVEL_' . $this->install_level] : '',
 			'DOWNLOADS'				=> isset($this->download_count) ? $this->download_count : 0,
 
-			'U_DOWNLOAD'		=> $this->get_url(),
-			'U_COLORIZEIT'      => $url_colorizeit,
-			'U_EDIT'			=> ($this->contrib && ($this->contrib->is_author || $this->contrib->is_active_coauthor || $this->contrib->type->acl_get('moderate'))) ? $this->contrib->get_url('revision', array('page' => 'edit', 'id' => $this->revision_id)) : '',
+			'U_DOWNLOAD'			=> $this->get_url(),
+			'U_COLORIZEIT'			=> $url_colorizeit,
+			'U_EDIT'				=> ($this->contrib && ($this->contrib->is_author || $this->contrib->is_active_coauthor || $this->contrib->type->acl_get('moderate'))) ? $this->contrib->get_url('revision', array('page' => 'edit', 'id' => $this->revision_id)) : '',
 
 			'S_USE_QUEUE'			=> (titania::$config->use_queue && $this->contrib->type->use_queue) ? true : false,
 			'S_NEW'					=> ($this->revision_status == ext::TITANIA_REVISION_NEW) ? true : false,
@@ -535,17 +535,17 @@ class titania_revision extends \phpbb\titania\entity\database_base
 		}
 
 		// Repack diff
-        titania::_include('tools/diff', false, 'titania_diff');
+		titania::_include('tools/diff', false, 'titania_diff');
 
 		$diff = (new titania_diff)
 			->set_renderer_type('diff_renderer_raw')
 			->set_ignore_equal_files(true)
-        	->from_zip($old_revision->get_attachment()->get_filepath(), $this->get_attachment()->get_filepath());
+			->from_zip($old_revision->get_attachment()->get_filepath(), $this->get_attachment()->get_filepath());
 
-        if ($diff !== false)
-        {
-            $repack_message .= '[quote=&quot;' . $this->user->lang('VALIDATION_DIFF') . '&quot;][code lang=diff]' . $diff . "[/code][/quote]\n";
-        }
+		if ($diff !== false)
+		{
+			$repack_message .= '[quote=&quot;' . $this->user->lang('VALIDATION_DIFF') . '&quot;][code lang=diff]' . $diff . "[/code][/quote]\n";
+		}
 
 		// Reply
 		$old_queue->topic_reply($repack_message);

--- a/includes/objects/revision.php
+++ b/includes/objects/revision.php
@@ -534,6 +534,19 @@ class titania_revision extends \phpbb\titania\entity\database_base
 			$repack_message .= '[quote=&quot;' . phpbb::$user->lang['VALIDATION_AUTOMOD'] . '&quot;]' . $queue->automod_results . "[/quote]\n";
 		}
 
+		// Repack diff
+        titania::_include('tools/diff', false, 'titania_diff');
+
+		$diff = (new titania_diff)
+			->set_renderer_type('diff_renderer_raw')
+			->set_ignore_equal_files(true)
+        	->from_zip($old_revision->get_attachment()->get_filepath(), $this->get_attachment()->get_filepath());
+
+        if ($diff !== false)
+        {
+            $repack_message .= '[quote=&quot;' . $this->user->lang('VALIDATION_DIFF') . '&quot;][code lang=diff]' . $diff . "[/code][/quote]\n";
+        }
+
 		// Reply
 		$old_queue->topic_reply($repack_message);
 

--- a/includes/tools/diff.php
+++ b/includes/tools/diff.php
@@ -11,19 +11,14 @@
 *
 */
 
+use Symfony\Component\Filesystem\Filesystem;
+
 /**
 * Class to create diffs for updated versions
 * @package Titania
 */
 class titania_diff
 {
-	/**
-	 * Classname of the diff renderer to use
-	 *
-	 * @var string
-	 */
-	private $renderer_type;
-
 	/**
 	 * Identification for old and new
 	 * This is used by from_dir to add an identification to the diff file
@@ -35,20 +30,25 @@ class titania_diff
 	/** @var string */
 	protected $ext_root_path;
 
+	/** @var string */
+	protected $renderer_type = 'diff_renderer_unified';
+
+	/** @var bool */
+	protected $ignore_equal_files = false;
+
 	/**
 	 * constructor
 	 *
 	 * @param string $renderer_type Classname of the renderer to use
 	 */
-	public function __construct($renderer_type = 'diff_renderer_unified')
+	public function __construct()
 	{
-		$this->renderer_type = $renderer_type;
 		$this->ext_root_path = \titania::$root_path;
 
-		phpbb::_include('diff/diff', false, 'diff');
-		phpbb::_include('diff/engine', false, 'diff');
-		phpbb::_include('diff/renderer', false, 'diff');
-		phpbb::_include('functions_compress', false, 'compress');
+		phpbb::_include('diff/diff', false, 'diff', false);
+		phpbb::_include('diff/engine', false, 'diff_engine', false);
+		phpbb::_include('diff/renderer', false, 'diff_renderer', false);
+		phpbb::_include('functions_compress', false, 'compress', false);
 	}
 
 	/**
@@ -63,6 +63,32 @@ class titania_diff
 		$this->id_new = $id_new;
 	}
 
+	/**
+	 * Classname of the diff renderer to use
+	 *
+	 * @param $renderer_type
+	 * @return titania_diff
+	 */
+	public function set_renderer_type($renderer_type)
+	{
+		$this->renderer_type = $renderer_type;
+
+		return $this;
+	}
+
+	/**
+	 * Whether or not unchanged file names should be listed
+	 *
+	 * @param $ignore_equal_files
+	 * @return titania_diff
+	 */
+	public function set_ignore_equal_files($ignore_equal_files)
+	{
+		$this->ignore_equal_files = $ignore_equal_files;
+
+		return $this;
+	}
+
 	// diff layers
 
 	/**
@@ -71,11 +97,11 @@ class titania_diff
 	 *
 	 * @param string $filename_old Path to old file
 	 * @param string $filename_new Path to new file
-	 * @return diff
+	 * @return string
 	 */
 	public function from_file($filename_old, $filename_new)
 	{
-	    $file_old = ($filename_old) ? self::file_contents($filename_old) : '';
+		$file_old = ($filename_old) ? self::file_contents($filename_old) : '';
 		$file_new = ($filename_new) ? self::file_contents($filename_new) : '';
 
 		// create renderer and process diff
@@ -88,12 +114,12 @@ class titania_diff
 	 *
 	 * @param string $dir_old Path to old dir
 	 * @param string $dir_new Path to new dir
-	 * @return diff
+	 * @return bool|string
 	 */
 	public function from_dir($dir_old, $dir_new)
 	{
-	    if (!file_exists($dir_old) || !file_exists($dir_new))
-	    {
+		if (!file_exists($dir_old) || !file_exists($dir_new))
+		{
 			return false;
 		}
 
@@ -106,26 +132,30 @@ class titania_diff
 
 		while (list($filename) = each($files_merged))
 		{
-			// add a context header for the file
-			$result .= "Index: $filename\n";
-			$result .= "===================================================================\n";
-			$result .= "--- $filename" . ($this->id_old ? "\t{$this->id_old}" : '') . "\n";
-			$result .= "+++ $filename" . ($this->id_new ? "\t{$this->id_new}" : '') . "\n";
+			$diff = '';
 
 			if (isset($files_old[$filename]) && isset($files_new[$filename]))
 			{
 				// old and new files exist
-				$result .= $this->from_file($dir_old . $filename, $dir_new . $filename) . "\n";
+				$diff .= $this->from_file($dir_old . $filename, $dir_new . $filename) . "\n";
 			}
 			else if (!isset($files_old[$filename]))
 			{
 				// old file doesn't exist, so it gets added
-				$result .= $this->from_file(false, $dir_new . $filename) . "\n";
+				$diff .= $this->from_file(false, $dir_new . $filename) . "\n";
 			}
 			else if (!isset($files_new[$filename]))
 			{
 				// new file doesn't exist, so it gets removed
-				$result .= $this->from_file($dir_old . $filename, false) . "\n";
+				$diff .= $this->from_file($dir_old . $filename, false) . "\n";
+			}
+
+			if (!$this->ignore_equal_files || trim($diff))
+			{
+				// add a context header for the file
+				$result .= "--- $filename" . ($this->id_old ? "\t{$this->id_old}" : '') . "\n";
+				$result .= "+++ $filename" . ($this->id_new ? "\t{$this->id_new}" : '') . "\n";
+				$result .= $diff;
 			}
 		}
 
@@ -137,12 +167,12 @@ class titania_diff
 	 *
 	 * @param string $filename_old Path to old zip file
 	 * @param string $filename_new Path to new zip file
-	 * @return diff
+	 * @return bool|string
 	 */
 	public function from_zip($filename_old, $filename_new)
 	{
-	    if (!file_exists($filename_old) || !file_exists($filename_new))
-	    {
+		if (!file_exists($filename_old) || !file_exists($filename_new))
+		{
 			return false;
 		}
 
@@ -151,15 +181,15 @@ class titania_diff
 		$tmp_new = $this->ext_root_path . 'files/temp/' . basename($filename_new) . '/';
 
 		// extract files
-		$result_old = self::extract_zip($filename_old, $tmp_old);
-		$result_new = self::extract_zip($filename_new, $tmp_new);
+		self::extract_zip($filename_old, $tmp_old);
+		self::extract_zip($filename_new, $tmp_new);
 
 		// get diff
 		$result = $this->from_dir($tmp_old, $tmp_new);
 
 		// clean up
-		self::rmdir($tmp_old, true);
-		self::rmdir($tmp_new, true);
+		(new Filesystem)->remove($tmp_old);
+		(new Filesystem)->remove($tmp_new);
 
 		return $result;
 	}
@@ -169,7 +199,7 @@ class titania_diff
 	 *
 	 * @param int $rev_old Old revision
 	 * @param int $rev_new New revision
-	 * @return diff
+	 * @return string
 	 */
 	public function from_revision($rev_old, $rev_new)
 	{
@@ -282,7 +312,7 @@ class titania_diff
 	 * Get contents of a file, don't mess up linefeeds
 	 *
 	 * @param string $filename Path to file
-	 * @return File contents
+	 * @return string contents
 	 */
 	public static function file_contents($filename)
 	{

--- a/language/en/manage.php
+++ b/language/en/manage.php
@@ -126,5 +126,5 @@ $lang = array_merge($lang, array(
 	'VALIDATION_PV'				=> 'Prevalidator Notes',
 	'VALIDATION_QUEUE'			=> 'Validation Queue',
 	'VALIDATION_SUBMISSION'		=> 'Validation Submission',
-    'VALIDATION_DIFF'			=> 'Repack Diff',
+    'VALIDATION_REPACK_DIFF'	=> 'Repack Diff',
 ));

--- a/language/en/manage.php
+++ b/language/en/manage.php
@@ -126,4 +126,5 @@ $lang = array_merge($lang, array(
 	'VALIDATION_PV'				=> 'Prevalidator Notes',
 	'VALIDATION_QUEUE'			=> 'Validation Queue',
 	'VALIDATION_SUBMISSION'		=> 'Validation Submission',
+    'VALIDATION_DIFF'			=> 'Repack Diff',
 ));


### PR DESCRIPTION
So Titania comes with a diff class that makes use of phpBB's core files for diffing that was written in 2008 but was never used. I updated it only where necessary and didn't overhaul it completely.

Notes:
* Previously, each entry in a diff result had a header along the lines of:
    ```
    Index: file.php
    =====================================
    ```
    I removed this.
* The resulting diff always included unchanged files. I added a switch to the diff class to be able to configure it to skip equal files, making the diff smaller and more readable.
* Including phpBB's core files for diffing threw an error about redeclaring classes when using Titania's `_include()` method, which is why I added a new optional argument to skip auto-including. I'm not sure if there's a better way to solve this.
* The `code` BBCode didn't always pick up the `diff`syntax because of too much PHP code in it. This is entirely the fault highlight.js, the library used by s9e/highlighter. I added an even listener that allows using `[code lang=xyz]` throughout Titania which forces the given syntax to be used. Thanks to @JoshyPHP for the code.

Comments and testers are welcome!

![repack](https://user-images.githubusercontent.com/6710357/30422307-d91850a6-993f-11e7-8be8-c757a1dc5c09.png)
