### PR TITLE
Set default value if S_ATTACH_DATA is not defined

### DIFF
--- a/styles/prosilver/template/plupload.html
+++ b/styles/prosilver/template/plupload.html
@@ -69,7 +69,7 @@ phpbb.plupload = {
 	},
 	order: '{ATTACH_ORDER}',
 	maxFiles: {MAX_ATTACHMENTS},
-	data: {S_ATTACH_DATA}
+	data: <!-- IF S_ATTACH_DATA -->{S_ATTACH_DATA}<!-- ELSE -->[]<!-- ENDIF -->
 }
 
 <!-- IF S_REVISION_FORM -->


### PR DESCRIPTION
When submitting a new revision, S_ATTACH_DATA is not defined, which turns this:

```
	data: {S_ATTACH_DATA}
}
```

to this invalid JS Code:

```
	data:
}
```

resulting in the entire `phpbb.plupload` object being undefined.