### PR TITLE
Only diff whitelisted files when repacking

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -145,6 +145,14 @@ class config extends \phpbb\titania\entity\base
 			'use_queue'					=> array('default' => true),
 			'allow_self_validation'		=> array('default' => true),
 
+			// File extensions that are included in a repack diff
+			'repack_diff_extensions'	=> array('default' => array(
+				'php',
+				'html', 'htm',
+				'js', 'css',
+				'cfg', 'json', 'yml', 'txt',
+			)),
+
 			// phpBB versions array
 			'phpbb_versions'			=> array('default' => array(
 				'20'	=> array('latest_revision' => '23', 'name' => 'phpBB 2.0.x', 'allow_uploads' => false),

--- a/includes/objects/revision.php
+++ b/includes/objects/revision.php
@@ -539,6 +539,17 @@ class titania_revision extends \phpbb\titania\entity\database_base
 
 		$diff = (new titania_diff)
 			->set_renderer_type('diff_renderer_raw')
+			->set_file_extensions(array(
+				'php',
+				'html',
+				'htm',
+				'css',
+				'js',
+				'cfg',
+				'json',
+				'yml',
+				'txt',
+			))
 			->set_ignore_equal_files(true)
 			->from_zip($old_revision->get_attachment()->get_filepath(), $this->get_attachment()->get_filepath());
 

--- a/includes/objects/revision.php
+++ b/includes/objects/revision.php
@@ -539,17 +539,7 @@ class titania_revision extends \phpbb\titania\entity\database_base
 
 		$diff = (new titania_diff)
 			->set_renderer_type('diff_renderer_raw')
-			->set_file_extensions(array(
-				'php',
-				'html',
-				'htm',
-				'css',
-				'js',
-				'cfg',
-				'json',
-				'yml',
-				'txt',
-			))
+			->set_file_extensions(titania::$config->repack_diff_extensions)
 			->set_ignore_equal_files(true)
 			->from_zip($old_revision->get_attachment()->get_filepath(), $this->get_attachment()->get_filepath());
 


### PR DESCRIPTION
@vinny reported a problem [in the other PR](https://github.com/phpbb/customisation-db/pull/238#issuecomment-331608863). In his first repack that resulted in an empty diff, a GIF image was deleted from the package. phpBB's differ doesn't skip binary files, and so the diff got corrupted by the null bytes in the GIF header. In the debugger the `$diff` value was truncated, I'm not sure why it ended up being empty in the post.

As a primitive solution for this, I added a fixed set of file extensions that are included in the diff. Files with other extensions are **not** listed in the diff.