### PR TITLE
Run various checks on extension revision version

### DIFF
--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -349,46 +349,15 @@ class type extends base
 	}
 
 	/**
-	 * Checks if the version is stable (1.2.3) or not (1.2.3-RC1)
+	 * Checks if the version is stable (1.2.3, 4.5.6-PL1) or not (7.8.9-RC1, 0.9.8)
 	 *
 	 * @param string $version
 	 * @return bool
 	 */
 	protected function is_stable_version($version)
 	{
-		$version = strtolower($version);
-
-		$unstable = array(
-			'rc',
-			'alpha',
-			'beta',
-			'dev',
-			'a',
-			'b',
-		);
-
-		$option = implode('|', $unstable);
-
-		// Check the version format and numbering
-		if (preg_match('#((\d+)\.)+(\d+)[a-z]?#', $version, $matches))
-		{
-			if (preg_match('#((\d+)\.)+(\d+)-(' . $option . '+)(\d+{0,)?#i', $version, $matches))
-			{
-				return false;
-			}
-
-			if (version_compare('1.0.0', $version) > 0)
-			{
-				return false;
-			}
-		}
-		else
-		{
-			// Not a valid version
-			return false;
-		}
-
-		return true;
+		// version_compare() doesn't understand -PLx
+		return preg_match('#^(\d+\.\d+\.\d+)(-pl\d+)?$#i', $version, $matches) === 1 && version_compare('1.0.0', $matches[1]) >= 0;
 	}
 
 	/**

--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -356,7 +356,7 @@ class type extends base
 	 */
 	protected function is_stable_version($version)
 	{
-		return preg_match('#^\d+\.\d+\.\d+(-pl\d+)?$#i', $version) === 1 && phpbb_version_compare('1.0.0', $version) >= 0;
+		return preg_match('#^\d+\.\d+\.\d+(-pl\d+)?$#i', $version) === 1 && phpbb_version_compare($version, '1.0.0', '>=');
 	}
 
 	/**

--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -356,8 +356,7 @@ class type extends base
 	 */
 	protected function is_stable_version($version)
 	{
-		// version_compare() doesn't understand -PLx
-		return preg_match('#^(\d+\.\d+\.\d+)(-pl\d+)?$#i', $version, $matches) === 1 && version_compare('1.0.0', $matches[1]) >= 0;
+		return preg_match('#^\d+\.\d+\.\d+(-pl\d+)?$#i', $version) === 1 && phpbb_version_compare('1.0.0', $version) >= 0;
 	}
 
 	/**

--- a/language/en/types/extension.php
+++ b/language/en/types/extension.php
@@ -128,12 +128,16 @@ If you have any queries and further discussion please use the Queue Discussion T
 Thank you,
 phpBB Extension Customisations Team',
 
-	'INVALID_COMPOSER_FILE'	=> 'Invalid composer.json file. The file either could not be read/written or it contains no data.',
-	'INVALID_EXT_NAME'		=> 'Invalid value for <em>name</em> property in composer.json.
-									Please refer to the <a href="https://www.phpbb.com/extensions/rules-and-policies/validation-policy/#packaging-extensions">Extension Validation Policy</a> for the valid format.',
-	'MISSING_EXT_NAME'		=> 'Missing value for <em>name</em> property in composer.json.',
+	'INVALID_COMPOSER_FILE'		=> 'Invalid composer.json file. The file either could not be read/written or it contains no data.',
+	'INVALID_EXT_NAME'			=> 'Invalid value for <em>name</em> property in composer.json.
+										Please refer to the <a href="https://www.phpbb.com/extensions/rules-and-policies/validation-policy/#packaging-extensions">Extension Validation Policy</a> for the valid format.',
+	'MISSING_EXT_NAME'			=> 'Missing value for <em>name</em> property in composer.json.',
+	'MISSING_COMPOSER_VERSION'	=> 'The composer.json file is missing the version property.',
+	'MISMATCH_COMPOSER_VERSION'	=> 'The version in the composer.json file ([b]%1$s[/b]) does not match the version of this revision ([b]%2$s[/b]).',
+	'UNSTABLE_COMPOSER_VERSION'	=> 'This revision has an unstable version. Please use a stable version number.
+										Refer to the <a href="https://www.phpbb.com/extensions/rules-and-policies/validation-policy/#packaging-extensions">Extension Validation Policy</a> for more information.',
 
-	'TEST_ACCOUNT'			=> 'Test account',
-	'TEST_ACCOUNT_EXPLAIN'	=> 'Do we need any information (Like an API key, username, password to login to a third party webservice) for testing your extension?
-									Please provide all required information to test your extension. <strong>If we are unable to test your extension because of missing information, we will deny your extension.</strong>',
+	'TEST_ACCOUNT'				=> 'Test account',
+	'TEST_ACCOUNT_EXPLAIN'		=> 'Do we need any information (Like an API key, username, password to login to a third party webservice) for testing your extension?
+										Please provide all required information to test your extension. <strong>If we are unable to test your extension because of missing information, we will deny your extension.</strong>',
 ));

--- a/language/en/types/extension.php
+++ b/language/en/types/extension.php
@@ -133,7 +133,7 @@ phpBB Extension Customisations Team',
 										Please refer to the <a href="https://www.phpbb.com/extensions/rules-and-policies/validation-policy/#packaging-extensions">Extension Validation Policy</a> for the valid format.',
 	'MISSING_EXT_NAME'			=> 'Missing value for <em>name</em> property in composer.json.',
 	'MISSING_COMPOSER_VERSION'	=> 'The composer.json file is missing the version property.',
-	'MISMATCH_COMPOSER_VERSION'	=> 'The version in the composer.json file ([b]%1$s[/b]) does not match the version of this revision ([b]%2$s[/b]).',
+	'MISMATCH_COMPOSER_VERSION'	=> 'The version in the composer.json file (%1$s) does not match the version of this revision (%2$s).',
 	'UNSTABLE_COMPOSER_VERSION'	=> 'This revision has an unstable version. Please use a stable version number.
 										Refer to the <a href="https://www.phpbb.com/extensions/rules-and-policies/validation-policy/#packaging-extensions">Extension Validation Policy</a> for more information.',
 


### PR DESCRIPTION
These changes make sure that:

- the version property in composer.json is present
- the version property in composer.json and the revision version entered by the user are the same
- the version is stable

The code of the `is_stable_version()` method was taken from [here](https://github.com/phpbb/mpv/blob/master/includes/tests/tests_modx.php#L181-L227) and was found by @paul999 within 17 nanoseconds.