### PR TITLE
Remove hardcoded repository links

### DIFF
--- a/manage/tool/composer/rebuild_repo.php
+++ b/manage/tool/composer/rebuild_repo.php
@@ -221,7 +221,7 @@ class rebuild_repo extends base
 					$group_count = $group = 1;
 				}
 				$last_type = $revision['contrib_type'];
-				/*$download_url = $this->path_helper->strip_url_params(
+				$download_url = $this->path_helper->strip_url_params(
 					$this->controller_helper->route('phpbb.titania.download',
 						array(
 							'id'	=> (int) $revision['attachment_id'],
@@ -238,11 +238,7 @@ class rebuild_repo extends base
 						)
 					),
 					'sid'
-				);*/
-				$contrib_url = 'https://www.phpbb.com/customise/db/' .
-					$this->types->get($revision['contrib_type'])->url . '/' .
-					$revision['contrib_name_clean'] . '/';
-				$download_url = 'https://www.phpbb.com/customise/db/download/' . (int) $revision['attachment_id'] . '/composer';
+				);
 
 				$packages = $this->repo->set_release(
 					$packages,


### PR DESCRIPTION
This would need to be tested on phpBB.com.

Go to `Manage > Administration > Rebuild Composer repository`

Then check the files created in `ext > phpbb > titania > composer_packages > prod > packages-extension-1.json`

Verify that the extensions listed in them have correct contrib and download URLs, e.g:

```
"homepage": "https://www.phpbb.com/customise/db/extension/ads/",

"dist": {
     "url": "https://www.phpbb.com/customise/db/download/156996/composer",
     "type": "zip"
 }
```
Unfortunately, I have no idea why @prototech hard coded this, but it should not be needed.
