### PR TITLE
Some navigation adjustments

### DIFF
--- a/assets/javascript/ajax.js
+++ b/assets/javascript/ajax.js
@@ -95,11 +95,8 @@
 		$('#queue-stats-link').remove();
 
 		if (res.u_queue_stats) {
-			var $queueStats = $('<a />')
-				.attr('href', res.u_queue_stats)
-				.html(res.l_queue_stats);
 			$('.titania-navigation').append(
-				$('<li />').attr('id', 'queue-stats-link').html($queueStats)
+				$('<a />').attr({'id': 'queue-stats-link', 'href': res.u_queue_stats}).html(res.l_queue_stats)
 			);
 		}
 

--- a/styles/prosilver/template/index_body.html
+++ b/styles/prosilver/template/index_body.html
@@ -2,17 +2,6 @@
 
 <h2>{L_CUSTOMISATION_DATABASE}</h2>
 
-<!-- IF .categories or U_QUEUE_STATS -->
-<ul class="linklist bulletin titania-navigation">
-	<!-- IF U_ALL_SUPPORT -->
-		<li><a href="{U_ALL_SUPPORT}">{L_ALL_SUPPORT}</a></li>
-	<!-- ENDIF -->
-	<!-- IF U_QUEUE_STATS -->
-		<li id="queue-stats-link"><a href="{U_QUEUE_STATS}">{L_QUEUE_STATS}</a></li>
-	<!-- ENDIF -->
-</ul>
-<!-- ENDIF -->
-
 	<div class="action-bar contrib-filter" style="margin-top: 2em;">
 		<!-- IF U_CREATE_CONTRIBUTION -->
 			<a href="{U_CREATE_CONTRIBUTION}" title="{L_NEW_CONTRIBUTION}" class="button">
@@ -90,6 +79,16 @@
 		<!-- IF categories.DEPTH and categories.S_LAST_ROW --></div><!-- ENDIF -->
 		{% set LAST_DEPTH = categories.DEPTH %}
 		<!-- END categories -->
+		<!-- IF .categories or U_QUEUE_STATS -->
+			<div class="titania-navigation">
+				<!-- IF U_ALL_SUPPORT -->
+					<a href="{U_ALL_SUPPORT}">{L_ALL_SUPPORT}</a>
+				<!-- ENDIF -->
+				<!-- IF U_QUEUE_STATS -->
+					<a id="queue-stats-link" href="{U_QUEUE_STATS}">{L_QUEUE_STATS}</a>
+				<!-- ENDIF -->
+			</div>
+		<!-- ENDIF -->
 	</div>
 
 <div class="contrib-list-container">

--- a/styles/prosilver/template/index_body.html
+++ b/styles/prosilver/template/index_body.html
@@ -7,9 +7,6 @@
 	<!-- IF U_ALL_SUPPORT -->
 		<li><a href="{U_ALL_SUPPORT}">{L_ALL_SUPPORT}</a></li>
 	<!-- ENDIF -->
-	<!-- IF U_FIND_CONTRIBUTION -->
-		<li><a href="{U_FIND_CONTRIBUTION}">{L_FIND_CONTRIBUTION}</a></li>
-	<!-- ENDIF -->
 	<!-- IF U_QUEUE_STATS -->
 		<li id="queue-stats-link"><a href="{U_QUEUE_STATS}">{L_QUEUE_STATS}</a></li>
 	<!-- ENDIF -->

--- a/styles/prosilver/theme/common.css
+++ b/styles/prosilver/theme/common.css
@@ -1028,3 +1028,7 @@ hr.solid {
 	content: '';
 	display: block;
 }
+
+.titania-navigation {
+	margin-top: 8px;
+}


### PR DESCRIPTION
One hack on .com is the page title "Customisations Database" is removed...probably to save space under the navbar and still have room for links to Support Topics and Queue Stats.

This PR will aim to restore the intended page title and move those ugly links to a more suitable location, in this case, the side bar.

Here is a before image:
![screen shot 2018-09-13 at 9 04 01 am](https://user-images.githubusercontent.com/303711/45501238-793d2480-b735-11e8-907b-5a2d87d37c94.png)

And here is what an after image would look like:
![screen shot 2018-09-13 at 9 03 34 am](https://user-images.githubusercontent.com/303711/45501252-80fcc900-b735-11e8-95de-fdab051917d2.png)
