### PR TITLE
Remove queue subscription on team removal

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -215,6 +215,7 @@ services:
             - '@template'
             - '@phpbb.titania.controller.helper'
             - '%core.root_path%'
+            - '%phpbb.titania.root_path%'
             - '%core.php_ext%'
         tags:
             - { name: event.listener }

--- a/config/services.yml
+++ b/config/services.yml
@@ -210,6 +210,7 @@ services:
     phpbb.titania.listener:
         class: phpbb\titania\event\main_listener
         arguments:
+            - '@dbal.conn'
             - '@user'
             - '@template'
             - '@phpbb.titania.controller.helper'

--- a/controller/helper.php
+++ b/controller/helper.php
@@ -101,12 +101,4 @@ class helper extends \phpbb\controller\helper
 	{
 		return parent::error($this->user->lang($message), $code);
 	}
-
-
-
-	// See if this is required or not??
-	public function include_dynamic_constants()
-	{
-		\titania::_include('dynamic_constants');
-	}
 }

--- a/controller/helper.php
+++ b/controller/helper.php
@@ -101,4 +101,12 @@ class helper extends \phpbb\controller\helper
 	{
 		return parent::error($this->user->lang($message), $code);
 	}
+
+
+
+	// See if this is required or not??
+	public function include_dynamic_constants()
+	{
+		\titania::_include('dynamic_constants');
+	}
 }

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -16,7 +16,10 @@ namespace phpbb\titania\event;
 use phpbb\db\driver\driver_interface as db_driver_interface;
 use phpbb\event\data;
 use phpbb\auth\auth;
+use phpbb\template\template;
+use phpbb\titania\controller\helper;
 use phpbb\titania\ext;
+use phpbb\user;
 use s9e\TextFormatter\Configurator\Items\TemplateDocument;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -61,7 +64,7 @@ class main_listener implements EventSubscriberInterface
 	 * @param string $ext_root_path Titania root path
 	 * @param string $php_ext PHP file extension
 	 */
-	public function __construct(db_driver_interface $db, \phpbb\user $user, \phpbb\template\template $template, \phpbb\titania\controller\helper $controller_helper, $phpbb_root_path, $ext_root_path, $php_ext)
+	public function __construct(db_driver_interface $db, user $user, template $template, helper $controller_helper, $phpbb_root_path, $ext_root_path, $php_ext)
 	{
 		$this->db = $db;
 		$this->user = $user;
@@ -288,7 +291,7 @@ class main_listener implements EventSubscriberInterface
 		}
 
 		// Only continue if there are users to remove from the Titania queue subscriptions
-		if (sizeof($remove_user_ids) > 0)
+		if (count($remove_user_ids))
 		{
 			// Remove subscription
 			$sql = 'DELETE FROM ' . TITANIA_WATCH_TABLE . '

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -44,19 +44,24 @@ class main_listener implements EventSubscriberInterface
 	/** @var string */
 	protected $php_ext;
 
+	/** @var string */
+	protected $ext_root_path;
+
 	/** @var bool */
 	protected $in_titania;
 
 	/**
-	* Constructor
-	*
-	* @param \phpbb\user $user
-	* @param \phpbb\template\template $template
-	* @param \phpbb\titania\controller\helper $controller_helper
-	* @param string	$phpbb_root_path	phpBB root path
-	* @param string	$php_ext			PHP file extension
-	*/
-	public function __construct(db_driver_interface $db, \phpbb\user $user, \phpbb\template\template $template, \phpbb\titania\controller\helper $controller_helper, $phpbb_root_path, $php_ext)
+	 * Constructor
+	 *
+	 * @param db_driver_interface $db
+	 * @param \phpbb\user $user
+	 * @param \phpbb\template\template $template
+	 * @param \phpbb\titania\controller\helper $controller_helper
+	 * @param string $phpbb_root_path phpBB root path
+	 * @param string $ext_root_path Titania root path
+	 * @param string $php_ext PHP file extension
+	 */
+	public function __construct(db_driver_interface $db, \phpbb\user $user, \phpbb\template\template $template, \phpbb\titania\controller\helper $controller_helper, $phpbb_root_path, $ext_root_path, $php_ext)
 	{
 		$this->db = $db;
 		$this->user = $user;
@@ -64,6 +69,7 @@ class main_listener implements EventSubscriberInterface
 		$this->controller_helper = $controller_helper;
 		$this->phpbb_root_path = $phpbb_root_path;
 		$this->php_ext = $php_ext;
+		$this->ext_root_path = $ext_root_path;
 		$this->in_titania = false;
 	}
 
@@ -164,7 +170,7 @@ class main_listener implements EventSubscriberInterface
 		}
 		$this->in_titania = true;
 
-		require($this->phpbb_root_path . 'ext/phpbb/titania/common.' . $this->php_ext);
+		require($this->ext_root_path . 'common.' . $this->php_ext);
 	}
 
 	public function overwrite_template_vars($event)
@@ -235,7 +241,8 @@ class main_listener implements EventSubscriberInterface
 	 */
 	public function remove_users_from_subscription($event)
 	{
-		$this->controller_helper->include_dynamic_constants();
+		// Include Titania so we can access the constants
+		require($this->ext_root_path . 'common.' . $this->php_ext);
 
 		$queue_permissions = array(
 			'u_titania_mod_extension_queue',

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -292,11 +292,8 @@ class main_listener implements EventSubscriberInterface
 			$sql = 'DELETE FROM ' . TITANIA_WATCH_TABLE . '
 					WHERE watch_user_id IN (' . implode(',', $remove_user_ids) . ')
 						AND watch_object_type = ' . ext::TITANIA_QUEUE;
-echo $sql . '<br /><br />';
-			//$this->db->sql_query($sql);
-		}
 
-		var_dump($event);
-		die();
+			$this->db->sql_query($sql);
+		}
 	}
 }

--- a/includes/objects/topic.php
+++ b/includes/objects/topic.php
@@ -354,6 +354,9 @@ class titania_topic extends \phpbb\titania\entity\database_base
 			));
 		}
 
+		// Don't allow negative replies; but show the number of replies minus the original post
+		$topic_replies = ($this->get_postcount() > 0) ? ($this->get_postcount() - 1) : 0;
+
 		$details = array(
 			'TOPIC_ID'						=> $this->topic_id,
 			'TOPIC_TYPE'					=> $this->topic_type,
@@ -365,7 +368,7 @@ class titania_topic extends \phpbb\titania\entity\database_base
 			'TOPIC_APPROVED'				=> (phpbb::$auth->acl_get('u_titania_mod_post_mod')) ? $this->topic_approved : true,
 			'TOPIC_REPORTED'				=> (phpbb::$auth->acl_get('u_titania_mod_post_mod')) ? $this->topic_reported : false,
 			'TOPIC_ASSIGNED'				=> $this->topic_assigned, // @todo output this to be something useful
-			'TOPIC_REPLIES'					=> ($this->get_postcount() - 1), // Number of replies (posts minus the OP)
+			'TOPIC_REPLIES'					=> $topic_replies,
 			'TOPIC_VIEWS'					=> $this->topic_views,
 			'TOPIC_SUBJECT'					=> censor_text($this->topic_subject),
 


### PR DESCRIPTION
When a user is removed from a group, do a permissions check to see if they can view any queues still (if so they are a team member, if not they wouldn't be). If they cannot view any queues then remove their queue subscription.

* Fixes "Team-level subscription not removed when user leaves team", https://tracker.phpbb.com/browse/CUSTDB-742
* Fixes "Negative number of replies", https://tracker.phpbb.com/browse/CUSTDB-382