### PR TITLE
Fix for contribs in hidden categories still showing everywhere

### DIFF
--- a/includes/overlords/contribs.php
+++ b/includes/overlords/contribs.php
@@ -220,7 +220,7 @@ class contribs_overlord
 				);
 
 				// Simplify it - just make it an array
-				if (is_integer($hierarchy_ids))
+				if (!is_array($hierarchy_ids))
 				{
 					$hierarchy_ids = array($hierarchy_ids);
 				}
@@ -379,7 +379,7 @@ class contribs_overlord
 			{
 				$contrib_categories = explode(',', $row['contrib_categories']);
 
-				if (count(array_diff($contrib_categories, $hidden_categories_ids)) == 0)
+				if (!count(array_diff($contrib_categories, $hidden_categories_ids)))
 				{
 					// Don't show it on the "all" listings page, because the contrib is only in hidden categories
 					continue;

--- a/includes/overlords/contribs.php
+++ b/includes/overlords/contribs.php
@@ -379,10 +379,9 @@ class contribs_overlord
 			{
 				$contrib_categories = explode(',', $row['contrib_categories']);
 
-				if (count($contrib_categories) === 1 && in_array($contrib_categories[0], $hidden_categories_ids))
+				if (count(array_diff($contrib_categories, $hidden_categories_ids)) == 0)
 				{
-					// If this contribution is only in one category, and that category is hidden, then don't
-					// show it on the "all" listings page.
+					// Don't show it on the "all" listings page, because the contrib is only in hidden categories
 					continue;
 				}
 			}

--- a/includes/overlords/contribs.php
+++ b/includes/overlords/contribs.php
@@ -379,7 +379,7 @@ class contribs_overlord
 			{
 				$contrib_categories = explode(',', $row['contrib_categories']);
 
-				if (sizeof($contrib_categories) == 1 && in_array($contrib_categories[0], $hidden_categories_ids))
+				if (count($contrib_categories) === 1 && in_array($contrib_categories[0], $hidden_categories_ids))
 				{
 					// If this contribution is only in one category, and that category is hidden, then don't
 					// show it on the "all" listings page.

--- a/includes/overlords/contribs.php
+++ b/includes/overlords/contribs.php
@@ -129,8 +129,10 @@ class contribs_overlord
 
 		while ($hidden_categories_row = phpbb::$db->sql_fetchrow($hidden_categories_result))
 		{
-			$hidden_categories_ids[] = (int)$hidden_categories_row['category_id'];
+			$hidden_categories_ids[] = (int) $hidden_categories_row['category_id'];
 		}
+
+		phpbb::$db->sql_freeresult($hidden_categories_result);
 
 		return $hidden_categories_ids;
 	}
@@ -139,12 +141,13 @@ class contribs_overlord
 	 * Display contributions
 	 *
 	 * @param string $mode The mode (category, author)
-	 * @param int $id The parent id (only show contributions under this category, author, etc)
-	 * @param int|bool $branch	Branch to limit results to: 20|30|31. Defaults to false.
+	 * @param int|array $id The parent id (only show contributions under this category, author, etc)
+	 * @param int|bool $branch Branch to limit results to: 20|30|31. Defaults to false.
 	 * @param \phpbb\titania\sort|bool $sort
 	 * @param string $blockname The name of the template block to use (contribs by default)
 	 *
 	 * @return array
+	 * @throws Exception
 	 */
 	public static function display_contribs($mode, $id, $branch = false, $sort = false, $blockname = 'contribs')
 	{
@@ -232,7 +235,7 @@ class contribs_overlord
 				asort($all_subcategory_ids);
 				asort($id);
 
-				if (serialize(array_values($all_subcategory_ids)) != serialize(array_values($id)))
+				if (array_values($all_subcategory_ids) != array_values($id))
 				{
 					// Remove the invisible category ids from the list of categories we check against
 					$visible_category_ids = array_diff($id, $hidden_categories_ids);


### PR DESCRIPTION
From https://tracker.phpbb.com/browse/CUSTDB-711

I wasn't able to replicate the first dot point, but I was for the second. Presumably there are reasons why someone might want to make a category invisible without totally cutting off access to contribs inside, so what I've done is made it so that the contribs from the hidden categories won't show on the "all" listing or on the parent category listing either. So the only way you can view it is if you explicitly go into that hidden category (eg. maybe someone wants to keep it private and supplies a direct link to trusted people or something).

How it looks now:

![kv4](https://user-images.githubusercontent.com/2110222/45586054-9f73e780-b922-11e8-9a8d-e59093b78bfe.png)
