### PR TITLE
Restore automated validation for 3.2 translations

### DIFF
--- a/contribution/translation/type.php
+++ b/contribution/translation/type.php
@@ -189,6 +189,9 @@ class type extends base
 		{
 			// If we have errors, display them
 			$return_value = array('error' => implode('<br /><br />', $errors));
+
+			// Show a checkbox to enable the user to submit despite the errors
+			$template->assign_var('S_IGNORE_VALIDATION_ERRORS', true);
 		}
 
 		else

--- a/contribution/translation/type.php
+++ b/contribution/translation/type.php
@@ -20,7 +20,6 @@ use phpbb\titania\config\config as ext_config;
 use phpbb\titania\contribution\type\base;
 use phpbb\titania\entity\package;
 use phpbb\user;
-use Symfony\Component\Finder\Finder;
 
 class type extends base
 {

--- a/contribution/translation/type.php
+++ b/contribution/translation/type.php
@@ -142,40 +142,40 @@ class type extends base
 	 */
 	private function translation_license_file_exists(package $package)
 	{
-		$license_file_exists = true;
-		$package->ensure_extracted();
-
-		/** @var Finder $finder */
-		$finder = $package->get_finder();
-
-		$directories = $finder
-			->directories()
-			->in($package->get_temp_path())
-			->name('language')
-			->depth(1); // Restrict the depth so we don't mistakenly search other language directories like viglink
-
-		// There should only be a single result for the root language/ folder
-		if (count($directories) === 1)
-		{
-			// Find the directory path
-			$iterator = $directories->getIterator();
-			$iterator->rewind();
-			$language_directory = $iterator->current();
-			$path_name = $language_directory->getPathname();
-
-			// Check for the license file
-			$license_file = $finder
-				->files()
-				->name('LICENSE')
-				->in($path_name);
-
-			if (!count($license_file))
-			{
-				$license_file_exists = false;
-			}
-		}
-
-		return $license_file_exists;
+//		$license_file_exists = false;
+//		$package->ensure_extracted();
+//
+//		/** @var Finder $finder */
+//		$finder = $package->get_finder();
+//
+//		$directories = $finder
+//			->directories()
+//			->in($package->get_temp_path())
+//			->name('language')
+//			->depth(1); // Restrict the depth so we don't mistakenly search other language directories like viglink
+//
+//		// There should only be a single result for the root language/ folder
+//		if (count($directories) === 1)
+//		{
+//			// Find the directory path
+//			$iterator = $directories->getIterator();
+//			$iterator->rewind();
+//			$language_directory = $iterator->current();
+//			$path_name = $language_directory->getPathname();
+//
+//			// Check for the license file
+//			$license_file = $finder
+//				->files()
+//				->name('LICENSE')
+//				->in($path_name);
+//
+//			if (count($license_file))
+//			{
+//				$license_file_exists = true;
+//			}
+//		}
+//
+//		return $license_file_exists;
 	}
 
 	/**
@@ -196,7 +196,7 @@ class type extends base
 			$revision->load_phpbb_versions();
 		}
 
-		$license_file_exists = $this->translation_license_file_exists($package);
+		/*$license_file_exists = $this->translation_license_file_exists($package);
 
 		if (!$license_file_exists)
 		{
@@ -206,11 +206,11 @@ class type extends base
 			);
 
 			return array('error' => $errors);
-		}
+		}*/
 
 		$version = $revision->phpbb_versions[0];
 
-		if ($version['phpbb_version_branch'] != 30)
+		if ($version['phpbb_version_branch'] == 30)
 		{
 			return array();
 		}

--- a/contribution/translation/type.php
+++ b/contribution/translation/type.php
@@ -152,6 +152,20 @@ class type extends base
 			$revision->load_phpbb_versions();
 		}
 
+		// Check whether the LICENSE file exists; if it doesn't then let the user know
+		$package->ensure_extracted();
+		$license_file = $package->find_directory(array('files' => array('required' => 'LICENSE')));
+
+		if (empty($license_file))
+		{
+			$errors = array(
+				// Inform the user that they must include a LICENSE file
+				$this->user->lang('ERROR_NO_TRANSLATION_LICENSE')
+			);
+
+			return array('error' => $errors);
+		}
+
 		$version = $revision->phpbb_versions[0];
 
 		if ($version['phpbb_version_branch'] != 30)

--- a/contribution/translation/type.php
+++ b/contribution/translation/type.php
@@ -136,49 +136,6 @@ class type extends base
 	}
 
 	/**
-	 * Check whether the LICENSE file exists; if it doesn't then let the user know
-	 * @param package $package
-	 * @return bool
-	 */
-	private function translation_license_file_exists(package $package)
-	{
-//		$license_file_exists = false;
-//		$package->ensure_extracted();
-//
-//		/** @var Finder $finder */
-//		$finder = $package->get_finder();
-//
-//		$directories = $finder
-//			->directories()
-//			->in($package->get_temp_path())
-//			->name('language')
-//			->depth(1); // Restrict the depth so we don't mistakenly search other language directories like viglink
-//
-//		// There should only be a single result for the root language/ folder
-//		if (count($directories) === 1)
-//		{
-//			// Find the directory path
-//			$iterator = $directories->getIterator();
-//			$iterator->rewind();
-//			$language_directory = $iterator->current();
-//			$path_name = $language_directory->getPathname();
-//
-//			// Check for the license file
-//			$license_file = $finder
-//				->files()
-//				->name('LICENSE')
-//				->in($path_name);
-//
-//			if (count($license_file))
-//			{
-//				$license_file_exists = true;
-//			}
-//		}
-//
-//		return $license_file_exists;
-	}
-
-	/**
 	 * Translation validation.
 	 *
 	 * @param \titania_contribution $contrib
@@ -196,21 +153,9 @@ class type extends base
 			$revision->load_phpbb_versions();
 		}
 
-		/*$license_file_exists = $this->translation_license_file_exists($package);
-
-		if (!$license_file_exists)
-		{
-			$errors = array(
-				// Inform the user that they must include a LICENSE file
-				$this->user->lang('ERROR_NO_TRANSLATION_LICENSE')
-			);
-
-			return array('error' => $errors);
-		}*/
-
 		$version = $revision->phpbb_versions[0];
 
-		if ($version['phpbb_version_branch'] == 30)
+		if ($version['phpbb_version_branch'] != 32)
 		{
 			return array();
 		}

--- a/controller/contribution/revision.php
+++ b/controller/contribution/revision.php
@@ -285,13 +285,21 @@ class revision extends base
 			}
 			else if (!isset($result['error']) || empty($result['error']))
 			{
-				$this->template->assign_var('STEP_MESSAGE', $this->user->lang['NEW_REVISION_READY']);
+				$user_display_message = $this->user->lang['NEW_REVISION_READY'];
 
 				// We can pass a flag to bypass translation validation
 				if ($this->request->variable('ignore_validation_errors', 0))
 				{
 					$this->template->assign_var('IGNORE_VALIDATION_ERRORS', true);
+
+					if ($this->request->variable('revision_id', 0))
+					{
+						// If the revision hasn't been created yet just show the regular processing message
+						$user_display_message = $this->user->lang['QUEUE_IGNORE_AND_SKIP'];
+					}
 				}
+
+				$this->template->assign_var('STEP_MESSAGE', $user_display_message);
 			}
 			$error = $result['error'];
 		}

--- a/controller/contribution/revision.php
+++ b/controller/contribution/revision.php
@@ -286,6 +286,12 @@ class revision extends base
 			else if (!isset($result['error']) || empty($result['error']))
 			{
 				$this->template->assign_var('STEP_MESSAGE', $this->user->lang['NEW_REVISION_READY']);
+
+				// We can pass a flag to bypass translation validation
+				if ($this->request->variable('ignore_validation_errors', 0))
+				{
+					$this->template->assign_var('IGNORE_VALIDATION_ERRORS', true);
+				}
 			}
 			$error = $result['error'];
 		}
@@ -745,7 +751,20 @@ class revision extends base
 
 		$hash = $this->package->get_md5_hash();
 
-		$result = $this->run_step($step['function']);
+		$ignore_validation_errors = $this->request->variable('ignore_validation_errors', 0);
+
+		if ($ignore_validation_errors && $step['function'][1] == 'translation_validate')
+		{
+			// Force submit: the user wants to submit a validation and they know there are errors
+			$result = '';
+		}
+
+		else
+		{
+			// Run the validation if it's not a translation and the user hasn't checked the ignore box
+			$result = $this->run_step($step['function']);
+		}
+
 		$result = $this->get_result($result, $steps, $step_num);
 
 		$this->package->cleanup();

--- a/controller/contribution/revision.php
+++ b/controller/contribution/revision.php
@@ -761,7 +761,7 @@ class revision extends base
 
 		$ignore_validation_errors = $this->request->variable('ignore_validation_errors', 0);
 
-		if ($ignore_validation_errors && $step['function'][1] == 'translation_validate')
+		if ($ignore_validation_errors && isset($step['function'][1]) && $step['function'][1] == 'translation_validate')
 		{
 			// Force submit: the user wants to submit a validation and they know there are errors
 			$result = '';

--- a/entity/package.php
+++ b/entity/package.php
@@ -127,7 +127,11 @@ class package
 		return ($this->source_exists()) ? md5_file($this->get_source()) : '';
 	}
 
-	protected function get_finder()
+	/**
+	 * Returns a Symfony Finder object
+	 * @return Finder
+	 */
+	public function get_finder()
 	{
 		$finder = new Finder;
 		return $finder

--- a/language/en/contributions.php
+++ b/language/en/contributions.php
@@ -121,7 +121,6 @@ $lang = array_merge($lang, array(
 	'EMPTY_CONTRIB_PERMALINK'				=> 'Enter your proposal for permalink for the contribution',
 	'EMPTY_CONTRIB_TYPE'					=> 'Select at least one contribution type',
 	'ERROR_CONTRIB_EMAIL_FRIEND'			=> 'You are not permitted to recommend this contribution to someone else.',
-	'ERROR_NO_TRANSLATION_LICENSE'			=> 'You must include a \'LICENSE\' file in the translation package.',
 
 	'INSTALL_DEMO'							=> 'Install',
 	'INSTALL_LESS_THAN_1_MINUTE'			=> 'Less Than One Minute',

--- a/language/en/contributions.php
+++ b/language/en/contributions.php
@@ -121,6 +121,7 @@ $lang = array_merge($lang, array(
 	'EMPTY_CONTRIB_PERMALINK'				=> 'Enter your proposal for permalink for the contribution',
 	'EMPTY_CONTRIB_TYPE'					=> 'Select at least one contribution type',
 	'ERROR_CONTRIB_EMAIL_FRIEND'			=> 'You are not permitted to recommend this contribution to someone else.',
+	'ERROR_UNSUPPORTED_VERSION'				=> 'Uploads for this phpBB version are not supported.',
 
 	'INSTALL_DEMO'							=> 'Install',
 	'INSTALL_LESS_THAN_1_MINUTE'			=> 'Less Than One Minute',

--- a/language/en/contributions.php
+++ b/language/en/contributions.php
@@ -178,6 +178,7 @@ $lang = array_merge($lang, array(
 
 	'QUEUE_IGNORE_ERRORS'					=> 'Submit With Validation Errors',
 	'QUEUE_IGNORE_ERRORS_EXPLAIN'			=> 'Ignore validation errors and continue with submission.',
+	'QUEUE_IGNORE_AND_SKIP'					=> 'Ignore validation errors and skip to revision submission.',
 	'QUEUE_ALLOW_REPACK'					=> 'Allow Repacking',
 	'QUEUE_ALLOW_REPACK_EXPLAIN'			=> 'Allow this contribution to be repacked for small errors?',
 	'QUEUE_NOTES'							=> 'Validation Notes',

--- a/language/en/contributions.php
+++ b/language/en/contributions.php
@@ -121,6 +121,7 @@ $lang = array_merge($lang, array(
 	'EMPTY_CONTRIB_PERMALINK'				=> 'Enter your proposal for permalink for the contribution',
 	'EMPTY_CONTRIB_TYPE'					=> 'Select at least one contribution type',
 	'ERROR_CONTRIB_EMAIL_FRIEND'			=> 'You are not permitted to recommend this contribution to someone else.',
+	'ERROR_NO_TRANSLATION_LICENSE'			=> 'You must include a \'LICENSE\' file in the translation package.',
 
 	'INSTALL_DEMO'							=> 'Install',
 	'INSTALL_LESS_THAN_1_MINUTE'			=> 'Less Than One Minute',

--- a/language/en/contributions.php
+++ b/language/en/contributions.php
@@ -176,6 +176,8 @@ $lang = array_merge($lang, array(
 	'PV_TEST'								=> 'Prevalidator test',
 	'PV_RESULTS'							=> '<strong>Please check over the prevalidator results and make sure that nothing needs to be fixed.<br /><br />If you do not think anything requires fixing or you are not sure, just hit continue below.</strong>',
 
+	'QUEUE_IGNORE_ERRORS'					=> 'Submit With Validation Errors',
+	'QUEUE_IGNORE_ERRORS_EXPLAIN'			=> 'Ignore validation errors and continue with submission.',
 	'QUEUE_ALLOW_REPACK'					=> 'Allow Repacking',
 	'QUEUE_ALLOW_REPACK_EXPLAIN'			=> 'Allow this contribution to be repacked for small errors?',
 	'QUEUE_NOTES'							=> 'Validation Notes',

--- a/language/en/types/translation.php
+++ b/language/en/types/translation.php
@@ -48,7 +48,7 @@ $lang = array_merge($lang, array(
 	'MISSING_FILE'								=> 'The file <code>%s</code> is missing in your language pack.',
 	'MISSING_KEYS'								=> 'You are missing the following language key(s) in <code>%1$s</code>:<br />%2$s',
 
-	'PASSED_VALIDATION'							=> 'Your language pack has been repacked and has passed the validation process which checks for missing keys, structure, additionnal files and license. Please continue.',
+	'PASSED_VALIDATION'							=> 'Your language pack has been repacked and has passed the validation process which checks for missing keys, structure, additional files and license. Please continue.',
 
 	'TRANSLATION'								=> 'Language Pack',
 	'TRANSLATION_VALIDATION'					=> '[phpBB Language Pack-Validation] %1$s %2$s',

--- a/styles/prosilver/template/contributions/contribution_revision.html
+++ b/styles/prosilver/template/contributions/contribution_revision.html
@@ -164,7 +164,7 @@
 				{AUTOMOD_RESULTS}
 			<!-- ENDIF -->
 			<!-- IF S_PASSED_TRANSLATION_VALIDATION -->
-				{L_PASSED_VALIDATION}
+				<div style="text-align:center;">{L_PASSED_VALIDATION}</div>
 			<!-- ENDIF -->
 
 			<fieldset class="submit-buttons">

--- a/styles/prosilver/template/contributions/contribution_revision.html
+++ b/styles/prosilver/template/contributions/contribution_revision.html
@@ -85,6 +85,20 @@
 				<input type="hidden" name="queue_allow_repack" value="{QUEUE_ALLOW_REPACK}" />
 				<!-- ENDIF -->
 
+				<!-- IF S_IGNORE_VALIDATION_ERRORS -->
+				<fieldset class="fields2">
+					<dl>
+						<dt>
+							<label for="ignore_validation_errors">{L_QUEUE_IGNORE_ERRORS}:</label><br />
+							<span>{L_QUEUE_IGNORE_ERRORS_EXPLAIN}</span>
+						</dt>
+						<dd>
+							<input type="checkbox" id="ignore_validation_errors" name="ignore_validation_errors" checked="checked" value="1">
+						</dd>
+					</dl>
+				</fieldset>
+				<!-- ENDIF -->
+
 				<!-- IF not S_REPACK and POSTING_TEXT_NAME -->
 				<fieldset class="fields2">
 				<dl>
@@ -124,6 +138,9 @@
 			<!-- IF STEP_MESSAGE -->
 				<div style="font-size:14px; padding:5px; width:100%; text-align:center;">
 					{STEP_MESSAGE}
+					<!-- IF IGNORE_VALIDATION_ERRORS -->
+					<input type="hidden" name="ignore_validation_errors" value="1" />
+					<!-- ENDIF -->
 				</div>
 			<!-- ENDIF -->
 			<!-- IF MPV_TEST_WARNING -->

--- a/styles/prosilver/template/contributions/contribution_revision.html
+++ b/styles/prosilver/template/contributions/contribution_revision.html
@@ -136,7 +136,7 @@
 				<!-- ENDIF -->
 			<!-- ENDIF -->
 			<!-- IF STEP_MESSAGE -->
-				<div style="font-size:14px; padding:5px; width:100%; text-align:center;">
+				<div class="validation-message-main">
 					{STEP_MESSAGE}
 					<!-- IF IGNORE_VALIDATION_ERRORS -->
 					<input type="hidden" name="ignore_validation_errors" value="1" />
@@ -164,7 +164,7 @@
 				{AUTOMOD_RESULTS}
 			<!-- ENDIF -->
 			<!-- IF S_PASSED_TRANSLATION_VALIDATION -->
-				<div style="text-align:center;">{L_PASSED_VALIDATION}</div>
+				<div class="validation-message">{L_PASSED_VALIDATION}</div>
 			<!-- ENDIF -->
 
 			<fieldset class="submit-buttons">

--- a/styles/prosilver/theme/common.css
+++ b/styles/prosilver/theme/common.css
@@ -1029,6 +1029,17 @@ hr.solid {
 	display: block;
 }
 
+.validation-message {
+	text-align: center;
+}
+
+.validation-message-main {
+	font-size: 14px;
+	padding: 5px;
+	width: 100%;
+	text-align: center;
+}
+
 .titania-navigation {
 	margin-top: 8px;
 }


### PR DESCRIPTION
Display a message to the user if they try and upload a language pack that doesn't contain a LICENSE file.

> You must include a 'LICENSE' file in the translation package. 

![kv5](https://user-images.githubusercontent.com/2110222/45598186-56975e00-ba0a-11e8-82b0-c974e53d51bb.png)

@Crizz0: Can a language pack contain more than one language? Like the example you gave me just had `\language\de` in it. But if there can be more than one language in that folder then I'll need to tweak this change.

Actually, come to think if it I might change this anyway do scan `language/` for directories and check to see if LICENSE is in each subdirectory, because the way it's currently written a user could whack a LICENSE file anywhere and this would validate. I guess it's best to make sure they've put in the language root.

https://tracker.phpbb.com/browse/CUSTDB-778