### PR TITLE
CUSTDB-780 - Responsive design for queue stats

### DIFF
--- a/styles/prosilver/template/queue_stats_body.html
+++ b/styles/prosilver/template/queue_stats_body.html
@@ -52,7 +52,9 @@
 		<!-- BEGIN dayrow -->
 			<span>
 				<span class="pip"></span>
-				<!-- IF (dayrow.S_FIRST_ROW or dayrow.S_LAST_ROW and (dayrow.DAY % 7) >= 3 ) or (dayrow.DAY % 7) == 0 or dayrow.MONTH_SWITCH-->{dayrow.MONTH}/{dayrow.DAY}<!-- ELSE -->&nbsp;<!-- ENDIF -->
+				<!-- IF (dayrow.S_FIRST_ROW or dayrow.S_LAST_ROW and (dayrow.DAY % 7) >= 3 ) or (dayrow.DAY % 7) == 0 or dayrow.MONTH_SWITCH-->
+				<span class="day-list-date">{dayrow.MONTH}/{dayrow.DAY}</span>
+				<!-- ELSE -->&nbsp;<!-- ENDIF -->
 			</span>
 		<!-- END dayrow -->
 		</div>

--- a/styles/prosilver/template/queue_stats_body.html
+++ b/styles/prosilver/template/queue_stats_body.html
@@ -26,42 +26,47 @@
 	<div class="inner">
 		<h3>{L_QUEUE_ACTIVITY_30_DAYS}</h3>
 		<!-- IF .dayrow -->
-		<div id="queue-activity">
-		<!-- BEGIN dayrow -->
-			<div class="stat-day" title="{dayrow.MONTH}/{dayrow.DAY}">
-				<span style="height: {dayrow.REMAINDER_PCT}%; margin-top: {dayrow.PIXEL_OFFSET}px;"></span>
-				<!-- IF dayrow.NEW_CNT -->
-					<span class="stat-new fade" style="height: {dayrow.NEW_PCT}%" title="{L_REVISION_NEW}: {dayrow.NEW_CNT}">
-					<!-- IF dayrow.NEW_PCT > 7 --><strong>{dayrow.NEW_CNT}</strong><!-- ENDIF -->
-					</span>
-				<!-- ENDIF -->
-				<!-- IF dayrow.DENIED_CNT -->
-					<span class="stat-denied fade" style="height: {dayrow.DENIED_PCT}%" title="{L_REVISION_DENIED}: {dayrow.DENIED_CNT}">
-					<!-- IF dayrow.DENIED_PCT > 7 --><strong>{dayrow.DENIED_CNT}</strong><!-- ENDIF -->
-					</span>
+		<div class="queue-statistics-box">
+			<div id="queue-activity">
+			<!-- BEGIN dayrow -->
+				<div class="stat-day" title="{dayrow.MONTH}/{dayrow.DAY}">
+					<span style="height: {dayrow.REMAINDER_PCT}%; margin-top: {dayrow.PIXEL_OFFSET}px;"></span>
+					<!-- IF dayrow.NEW_CNT -->
+						<span class="stat-new fade" style="height: {dayrow.NEW_PCT}%" title="{L_REVISION_NEW}: {dayrow.NEW_CNT}">
+						<!-- IF dayrow.NEW_PCT > 7 --><strong>{dayrow.NEW_CNT}</strong><!-- ENDIF -->
+						</span>
 					<!-- ENDIF -->
-				<!-- IF dayrow.APPROVED_CNT -->
-					<span class="stat-approved fade" style="height: {dayrow.APPROVED_PCT}%" title="{L_REVISION_APPROVED}: {dayrow.APPROVED_CNT}">
-					<!-- IF dayrow.APPROVED_PCT > 7 --><strong>{dayrow.APPROVED_CNT}</strong><!-- ENDIF -->
-					</span>
-				<!-- ENDIF -->
+					<!-- IF dayrow.DENIED_CNT -->
+						<span class="stat-denied fade" style="height: {dayrow.DENIED_PCT}%" title="{L_REVISION_DENIED}: {dayrow.DENIED_CNT}">
+						<!-- IF dayrow.DENIED_PCT > 7 --><strong>{dayrow.DENIED_CNT}</strong><!-- ENDIF -->
+						</span>
+						<!-- ENDIF -->
+					<!-- IF dayrow.APPROVED_CNT -->
+						<span class="stat-approved fade" style="height: {dayrow.APPROVED_PCT}%" title="{L_REVISION_APPROVED}: {dayrow.APPROVED_CNT}">
+						<!-- IF dayrow.APPROVED_PCT > 7 --><strong>{dayrow.APPROVED_CNT}</strong><!-- ENDIF -->
+						</span>
+					<!-- ENDIF -->
+				</div>
+			<!-- END dayrow -->
 			</div>
-		<!-- END dayrow -->
+			<div class="day-list">
+			<!-- BEGIN dayrow -->
+				<span>
+					<span class="pip"></span>
+					<!-- IF (dayrow.S_FIRST_ROW or dayrow.S_LAST_ROW and (dayrow.DAY % 7) >= 3 ) or (dayrow.DAY % 7) == 0 or dayrow.MONTH_SWITCH-->
+					<span class="day-list-date">{dayrow.MONTH}/{dayrow.DAY}</span>
+					<!-- ELSE -->&nbsp;<!-- ENDIF -->
+				</span>
+			<!-- END dayrow -->
+			</div>
 		</div>
-		<div class="day-list">
-		<!-- BEGIN dayrow -->
-			<span>
-				<span class="pip"></span>
-				<!-- IF (dayrow.S_FIRST_ROW or dayrow.S_LAST_ROW and (dayrow.DAY % 7) >= 3 ) or (dayrow.DAY % 7) == 0 or dayrow.MONTH_SWITCH-->
-				<span class="day-list-date">{dayrow.MONTH}/{dayrow.DAY}</span>
-				<!-- ELSE -->&nbsp;<!-- ENDIF -->
-			</span>
-		<!-- END dayrow -->
+		<div class="queue-statistics-box">
+			<p>
+				<span class="legend stat-new"></span> {L_REVISION_NEW}
+				<span class="legend stat-denied"></span> {L_REVISION_DENIED}
+				<span class="legend stat-approved"></span> {L_REVISION_APPROVED}
+			</p>
 		</div>
-		<span class="clear"></span>
-		<p>
-			<span class="legend stat-new"></span> {L_REVISION_NEW} <span class="legend stat-denied"></span> {L_REVISION_DENIED} <span class="legend stat-approved"></span> {L_REVISION_APPROVED}
-		</p>
 		<!-- ELSE -->
 			<p>{L_NO_QUEUE_ACTIVITY}</p>
 		<!-- ENDIF -->

--- a/styles/prosilver/template/queue_stats_body.html
+++ b/styles/prosilver/template/queue_stats_body.html
@@ -11,14 +11,20 @@
 					<!-- ENDIF -->
 					<li>{AVG_PAST_VALIDATION_TIME}</li>
 					<li>{SINCE_X_VALIDATED_REVS}</li>
-					<li>{L_APPROVAL_DENIAL_RATE}:
-						<div class="stat-ratio">
-							<!-- IF APPROVED_RATIO --><span class="stat-approved" style="width: {APPROVED_RATIO}%">{APPROVED_RATIO}%</span><!-- ENDIF -->
-							<!-- IF DENIED_RATIO --><span class="stat-denied" style="width: {DENIED_RATIO}%">{DENIED_RATIO}%</span><!-- ENDIF -->
-						</div>
-					</li>
 				</ul>
 			</div>
+	</div>
+</div>
+
+<div class="panel">
+	<div class="inner">
+		<h3>{L_APPROVAL_DENIAL_RATE}</h3>
+		<div class="queue-statistics-box">
+			<div class="stat-ratio">
+				<!-- IF APPROVED_RATIO --><span class="stat-approved" style="width: {APPROVED_RATIO}%">{APPROVED_RATIO}%</span><!-- ENDIF -->
+				<!-- IF DENIED_RATIO --><span class="stat-denied" style="width: {DENIED_RATIO}%">{DENIED_RATIO}%</span><!-- ENDIF -->
+			</div>
+		</div>
 	</div>
 </div>
 

--- a/styles/prosilver/theme/common.css
+++ b/styles/prosilver/theme/common.css
@@ -949,7 +949,10 @@ p.attention-closed {
 	width: 20px;
 }
 
-.stat-ratio { width: 300px; }
+.stat-ratio {
+	width: 80%;
+	margin: 25px 0;
+}
 
 .stat-ratio span {
 	height: 16px;

--- a/styles/prosilver/theme/common.css
+++ b/styles/prosilver/theme/common.css
@@ -972,6 +972,12 @@ p.attention-closed {
 	font-size: 1.0em;
 }
 
+.queue-statistics-box {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+}
+
 .stat-day span strong {
 	font-weight: normal;
 	height: 10px;

--- a/styles/prosilver/theme/common.css
+++ b/styles/prosilver/theme/common.css
@@ -968,6 +968,10 @@ p.attention-closed {
 	position: relative;
 }
 
+.day-list-date {
+	font-size: 1.0em;
+}
+
 .stat-day span strong {
 	font-weight: normal;
 	height: 10px;

--- a/styles/prosilver/theme/responsive.css
+++ b/styles/prosilver/theme/responsive.css
@@ -134,3 +134,4 @@
 		width: 100% !important;
 	}
 }
+

--- a/styles/prosilver/theme/responsive.css
+++ b/styles/prosilver/theme/responsive.css
@@ -1,4 +1,27 @@
+/* Queue stats */
+@media only screen and (max-width: 890px), only screen and (max-device-width: 890px) {
+	.day-list span {
+		width: 9px;
+	}
+
+	.day-list-date {
+		font-size: 0.4em;
+	}
+
+	.stat-day {
+		margin-right: 1px;
+	}
+
+	.stat-ratio span, .stat-day span {
+		width: 8px;
+	}
+}
+
 @media only screen and (max-width: 700px), only screen and (max-device-width: 700px) {
+	.day-list-date {
+		color: red; /* JUST FOR TESTING */
+	}
+
 	/* Contribution List
 	--------------------------------------------- */
 	.contrib-list-container {
@@ -36,6 +59,10 @@
 }
 
 @media only screen and (max-width: 550px), only screen and (max-device-width: 550px) {
+	.day-list-date {
+		color: green; /* JUST FOR TESTING */
+	}
+
 	/* Contribution Details
 	--------------------------------------------- */
 	.left-column {
@@ -72,6 +99,10 @@
 }
 
 @media only screen and (max-width: 400px), only screen and (max-device-width: 400px) {
+	.day-list-date {
+		color: blue; /* JUST FOR TESTING */
+	}
+
 	/* Contribution List
 	--------------------------------------------- */
 	.contrib-quickview {

--- a/styles/prosilver/theme/responsive.css
+++ b/styles/prosilver/theme/responsive.css
@@ -1,5 +1,42 @@
-/* Queue stats */
+/* Responsive queue statistics
+--------------------------------------------- */
 @media only screen and (max-width: 890px), only screen and (max-device-width: 890px) {
+	.day-list span {
+		width: 16px;
+	}
+
+	.day-list-date {
+		font-size: 0.6em;
+	}
+
+	.stat-day {
+		margin-right: 1px;
+	}
+
+	.stat-ratio span, .stat-day span {
+		width: 15px;
+	}
+}
+
+@media only screen and (max-width: 520px), only screen and (max-device-width: 520px) {
+	.day-list span {
+		width: 12px;
+	}
+
+	.day-list-date {
+		font-size: 0.4em;
+	}
+
+	.stat-day {
+		margin-right: 1px;
+	}
+
+	.stat-ratio span, .stat-day span {
+		width: 11px;
+	}
+}
+
+@media only screen and (max-width: 385px), only screen and (max-device-width: 385px) {
 	.day-list span {
 		width: 9px;
 	}
@@ -18,10 +55,6 @@
 }
 
 @media only screen and (max-width: 700px), only screen and (max-device-width: 700px) {
-	.day-list-date {
-		color: red; /* JUST FOR TESTING */
-	}
-
 	/* Contribution List
 	--------------------------------------------- */
 	.contrib-list-container {
@@ -59,10 +92,6 @@
 }
 
 @media only screen and (max-width: 550px), only screen and (max-device-width: 550px) {
-	.day-list-date {
-		color: green; /* JUST FOR TESTING */
-	}
-
 	/* Contribution Details
 	--------------------------------------------- */
 	.left-column {
@@ -99,10 +128,6 @@
 }
 
 @media only screen and (max-width: 400px), only screen and (max-device-width: 400px) {
-	.day-list-date {
-		color: blue; /* JUST FOR TESTING */
-	}
-
 	/* Contribution List
 	--------------------------------------------- */
 	.contrib-quickview {


### PR DESCRIPTION
https://tracker.phpbb.com/projects/CUSTDB/issues/CUSTDB-780

The queue stats weren't displaying properly for smaller displays. This change makes it look better for four screen sizes:

* Very small (385px width or less)
* Small (385-520)
* Medium (520-890)
* Large (890px and larger)
  * This is the default, the other three settings I added media queries for in `responsive.css`.

The stats graph and legend is centre aligned now, and I've split the approval/denial rate graph into its own section, so it should look like this now:

![graph2](https://user-images.githubusercontent.com/2110222/48952090-eeba4200-ef7b-11e8-95e8-6317ff6254d7.png)