### PR TITLE
CUSTDB-765 - Missing index on attachment comment field

### DIFF
--- a/attachment/uploader.php
+++ b/attachment/uploader.php
@@ -386,7 +386,7 @@ class uploader
 				'FILENAME'			=> $attach->get_filename(),
 				'FILE_COMMENT'		=> (isset($comments[$attachment_id])) ? $comments[$attachment_id] : $attach->get('attachment_comment'),
 				'ATTACH_ID'			=> $attachment_id,
-				'INDEX'				=> $index_prefix . $index,
+				'ASSOC_INDEX'		=> $index_prefix . $index,
 				'FILESIZE'			=> get_formatted_filesize($attach->get('filesize')),
 
 				'S_HIDDEN'			=> build_hidden_fields($_hidden_data),


### PR DESCRIPTION
Full discussion at https://tracker.phpbb.com/projects/CUSTDB/issues/CUSTDB-765

I think this might be the reason why the attachment comments become inverted upon saving. The comment_list[] indexes were empty - the template was expecting `ASSOC_INDEX` but that wasn't defined when assigning the template vars.