### PR TITLE
[CUSTDB-785] Hide MOD validation queue now that it is no longer used

### DIFF
--- a/contribution/mod/type.php
+++ b/contribution/mod/type.php
@@ -117,7 +117,7 @@ class type extends base
 
 			// Can view the mod queue
 			case 'view' :
-				return $this->auth->acl_get('u_titania_mod_modification_queue');
+				return false; // Disabled as no new MODs will be entering the queue
 			break;
 
 			// Can validate mods in the queue


### PR DESCRIPTION
Stop showing the Modifications category in the validation queue area:

![ch18](https://user-images.githubusercontent.com/2110222/56845025-2ba0b100-68ed-11e9-9bb8-9ca4da7f2900.png)

https://tracker.phpbb.com/projects/CUSTDB/issues/CUSTDB-785