### PR TITLE
Use rename instead of mirror for package temp folders

### DIFF
--- a/entity/package.php
+++ b/entity/package.php
@@ -331,15 +331,16 @@ class package
 		{
 			$this->filesystem->mkdir($copy_root_path);
 		}
-		$this->filesystem->mirror($root_path, $copy_root_path);
-		$this->filesystem->remove($root_path);
+
+		$this->filesystem->rename($root_path, $copy_root_path, true);
 		$this->filesystem->remove($temp_path);
+
 		if ($new_name)
 		{
 			$this->filesystem->mkdir($new_root_path);
 		}
-		$this->filesystem->mirror($copy_root_path, $new_root_path);
-		$this->filesystem->remove($copy_root_path);
+
+		$this->filesystem->rename($copy_root_path, $new_root_path, true);
 		$this->filesystem->remove($copy_path);
 	}
 


### PR DESCRIPTION
To have a better idea of what's happening in the `restore_root()` method, some example paths:

```
$directory      = "vendor/ext"
$new_name       = "vendor/ext"
$temp_path      = "./ext/phpbb/titania/files/contrib_temp/abc_123"
$copy_path      = "./ext/phpbb/titania/files/contrib_temp/abc_123_repack/"
$copy_root_path = "./ext/phpbb/titania/files/contrib_temp/abc_123_repack/vendor/ext"
$root_path      = "./ext/phpbb/titania/files/contrib_temp/abc_123/vendor/ext"
$new_root_path  = "./ext/phpbb/titania/files/contrib_temp/abc_123/vendor/ext"
```
