### PR TITLE
[CUSTDB-795] Check extension name against display name

### DIFF
--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -267,6 +267,10 @@ class type extends base
 		{
 			throw new \Exception('UNSTABLE_COMPOSER_VERSION');
 		}
+		if ($data['extra']['display-name'] !== $contrib->contrib_name)
+		{
+			throw new \Exception($this->user->lang('MISMATCH_DISPLAY_NAME', $data['extra']['display-name'], $contrib->contrib_name));
+		}
 
 		$ext_name = $data['name'];
 		$data['type'] = 'phpbb-extension';

--- a/language/en/types/extension.php
+++ b/language/en/types/extension.php
@@ -134,6 +134,7 @@ phpBB Extension Customisations Team',
 	'MISSING_EXT_NAME'			=> 'Missing value for <em>name</em> property in composer.json.',
 	'MISSING_COMPOSER_VERSION'	=> 'The composer.json file is missing the version property.',
 	'MISMATCH_COMPOSER_VERSION'	=> 'The version in the composer.json file (%1$s) does not match the version of this revision (%2$s).',
+	'MISMATCH_DISPLAY_NAME'		=> 'The display name in the composer.json file (%1$s) does not match the extension name (%2$s).',
 	'UNSTABLE_COMPOSER_VERSION'	=> 'This revision has an unstable version. Please use a stable version number.
 										Refer to the <a href="https://www.phpbb.com/extensions/rules-and-policies/validation-policy/#packaging-extensions">Extension Validation Policy</a> for more information.',
 


### PR DESCRIPTION
This change warns users if the display name inside the composer.json file doesn't match the extension name.

![image](https://user-images.githubusercontent.com/2110222/65854170-6fad4b80-e38e-11e9-8462-dfa1507515f2.png)

https://tracker.phpbb.com/projects/CUSTDB/issues/CUSTDB-795