### PR TITLE
[CUSTDB-465] phpBB Package Builder

### DIFF
--- a/assets/javascript/ajax.js
+++ b/assets/javascript/ajax.js
@@ -141,6 +141,17 @@
 		});
 	};
 
+	phpbb.addAjaxCallback('titania.package.builder.add', function(result) {
+		var $revision = $(this).data('revision-id');
+
+		// Hide the other buttons
+		$('.package-builder-add').has('a:not([data-revision-id="' + $revision + '"])').hide();
+
+		// Change the button that was clicked
+		$('.package-builder-add > a').remove();
+		$('.package-builder-add').append('<span class="package-builder-download-prompt">' + result.message + '</span>');
+	});
+
 	phpbb.addAjaxCallback('titania.rate', function(res) {
 		if (res.rating) {
 			var $rating = $(res.rating);

--- a/config/controllers.yml
+++ b/config/controllers.yml
@@ -15,6 +15,20 @@ services:
             - '@phpbb.titania.config'
             - '@phpbb.titania.tracking'
 
+    phpbb.titania.controller.package_builder:
+        class: phpbb\titania\controller\package_builder
+        arguments:
+            - '@dbal.conn'
+            - '@template'
+            - '@config'
+            - '@user'
+            - '@language'
+            - '@phpbb.titania.controller.helper'
+            - '@phpbb.titania.cache'
+            - '@request'
+            - '@phpbb.titania.config'
+            - '%phpbb.titania.root_path%'
+
     phpbb.titania.controller.faq:
         class: phpbb\titania\controller\faq
         arguments:

--- a/config/routes/general.yml
+++ b/config/routes/general.yml
@@ -16,6 +16,18 @@ phpbb.titania.faq:
     path: /faq
     defaults: { _controller: phpbb.titania.controller.faq:handle }
 
+phpbb.titania.package_builder.add:
+    path: /package-builder/add/{contrib}/{revision}
+    defaults: { _controller: phpbb.titania.controller.package_builder:add }
+
+phpbb.titania.package_builder.reset:
+    path: /package-builder/reset
+    defaults: { _controller: phpbb.titania.controller.package_builder:reset }
+
+phpbb.titania.package_builder.download:
+    path: /package-builder/download
+    defaults: { _controller: phpbb.titania.controller.package_builder:download }
+
 phpbb.titania.queue_stats:
     path: /queue-stats/{contrib_type}
     defaults: { _controller: phpbb.titania.controller.queue_stats:display_stats }

--- a/controller/package_builder.php
+++ b/controller/package_builder.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Customisation Database package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\titania\controller;
+
+use phpbb\titania\ext;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class package_builder
+{
+	const COOKIE_NAME = 'cdb_package_builder';
+
+	/** @var \phpbb\db\driver\driver_interface */
+	protected $db;
+
+	/** @var \phpbb\template\template */
+	protected $template;
+
+	/** @var \phpbb\config\config */
+	protected $config;
+
+	/** @var \phpbb\user */
+	protected $user;
+
+	/** @var \phpbb\language\language */
+	protected $language;
+
+	/** @var \phpbb\titania\controller\helper */
+	protected $helper;
+
+	/** @var \phpbb\titania\cache\service */
+	protected $cache;
+
+	/** @var \phpbb\request\request_interface */
+	protected $request;
+
+	/** @var \phpbb\titania\config\config */
+	protected $ext_config;
+
+	/** @var string */
+	protected $ext_root_path;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \phpbb\db\driver\driver_interface $db
+	 * @param \phpbb\template\template $template
+	 * @param \phpbb\config\config $config
+	 * @param \phpbb\user $user
+	 * @param \phpbb\language\language $language
+	 * @param \phpbb\titania\controller\helper $helper
+	 * @param \phpbb\titania\cache\service $cache
+	 * @param \phpbb\request\request_interface $request
+	 * @param \phpbb\titania\config\config $ext_config
+	 * @param $ext_root_path
+	 */
+	public function __construct(\phpbb\db\driver\driver_interface $db, \phpbb\template\template $template, \phpbb\config\config $config, \phpbb\user $user, \phpbb\language\language $language, \phpbb\titania\controller\helper $helper, \phpbb\titania\cache\service $cache, \phpbb\request\request_interface $request, \phpbb\titania\config\config $ext_config, $ext_root_path)
+	{
+		$this->db = $db;
+		$this->template = $template;
+		$this->config = $config;
+		$this->user = $user;
+		$this->language = $language;
+		$this->helper = $helper;
+		$this->cache = $cache;
+		$this->request = $request;
+		$this->ext_config = $ext_config;
+		$this->ext_root_path = $ext_root_path;
+	}
+
+	/**
+	 * Get the cookie name
+	 * @return string
+	 */
+	private function get_cookie_name()
+	{
+		return $this->config['cookie_name'] . '_' . self::COOKIE_NAME;
+	}
+
+	/**
+	 * Save the cookie
+	 * @param $cookie_value
+	 */
+	private function save_cookie($cookie_value)
+	{
+		// One hour expiry
+		$this->user->set_cookie(self::COOKIE_NAME, $cookie_value, time() + (60 * 60));
+	}
+
+	/**
+	 * Get the revisions and contributions already selected out of the cookie value
+	 * @param $value
+	 * @return array
+	 */
+	public static function split_cookie_values($value)
+	{
+		$results = [
+			'contribs' => [],
+			'revisions' => [],
+		];
+
+		$values = explode(',', $value);
+
+		foreach ($values as $item)
+		{
+			if (strlen($item) > 0)
+			{
+				$split = explode('|', $item);
+
+				$results['contribs'][] = $split[0];
+				$results['revisions'][] = $split[1];
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Create a json response
+	 * @param $success
+	 * @param $values
+	 * @param string $message
+	 * @return JsonResponse
+	 */
+	private function create_json_response($success, $values, $message = '')
+	{
+		$json = [
+			'success' => $success,
+			'values' => $values,
+		];
+
+		if (!empty($message))
+		{
+			$json['message'] = $message;
+		}
+
+		return new JsonResponse($json);
+	}
+
+	/**
+	 * Clear the existing values saved in the cookie
+	 */
+	public function reset()
+	{
+		$this->save_cookie('');
+
+		return $this->create_json_response(true, '');
+	}
+
+	/**
+	 * Download the completed package
+	 * @throws \phpbb\titania\entity\UnknownPropertyException
+	 */
+	public function download()
+	{
+		$versions = $this->cache->get_phpbb_versions();
+		$latest_version = reset($versions);
+
+		$phpbb_package = $this->ext_root_path . 'includes/phpbb_packages/phpBB-' . $latest_version . '.zip';
+		$extract_path = $this->ext_config->__get('contrib_temp_path') . 'tmp/package_' . $this->user->data['user_id'];
+
+		$zip = new \ZipArchive();
+
+		if ($zip->open($phpbb_package))
+		{
+			// Unzip the revision to a temporary folder
+			$zip->extractTo($extract_path);
+			$zip->close();
+
+			// Take the revisions from the cookies, and plug them into the phpBB3 instance
+			// extensions to ext/, styles to style/ and language packs to language/
+			$existing_cookie = $this->request->variable($this->get_cookie_name(), '', false, \phpbb\request\request_interface::COOKIE);
+			$existing_values = self::split_cookie_values($existing_cookie);
+
+			// Get the attachments
+			$sql = 'SELECT r.revision_id, c.contrib_id, a.attachment_directory, a.physical_filename, c.contrib_type
+					FROM ' . TITANIA_REVISIONS_TABLE . ' r, ' . TITANIA_ATTACHMENTS_TABLE . ' a, ' . TITANIA_CONTRIBS_TABLE . ' c
+					WHERE r.attachment_id = a.attachment_id
+						AND c.contrib_id = r.contrib_id
+					AND ' . $this->db->sql_in_set('r.revision_id', $existing_values['revisions']);
+
+			$result = $this->db->sql_query($sql);
+
+			while ($row = $this->db->sql_fetchrow($result))
+			{
+				// TODO: Check that the revision ID hasn't been manipulated and this user has access to download the revision
+
+				$contribution_archive = $this->ext_config->upload_path . $row['attachment_directory'] . '/' . $row['physical_filename'];
+
+				$zip = new \ZipArchive();
+
+				if ($zip->open($contribution_archive))
+				{
+					if ($row['contrib_type'] == ext::TITANIA_TYPE_EXTENSION)
+					{
+						$zip->extractTo($extract_path . '/phpBB3/ext');
+					}
+
+					if ($row['contrib_type'] == ext::TITANIA_TYPE_STYLE)
+					{
+						$zip->extractTo($extract_path . '/phpBB3/style');
+					}
+
+					if ($row['contrib_type'] == ext::TITANIA_TYPE_TRANSLATION)
+					{
+						// TODO: talk to Crizzo about where these need to end up being moved to
+						$zip->extractTo($extract_path . '/phpBB3/language');
+					}
+
+					$zip->close();
+				}
+			}
+
+			// TODO: Zip up the final package and send it to the browser
+		}
+	}
+
+	/**
+	 * Add a revision ID
+	 * @param $contrib
+	 * @param $revision
+	 * @return JsonResponse
+	 */
+	public function add($contrib, $revision)
+	{
+		$json = null;
+
+		$existing_cookie = $this->request->variable($this->get_cookie_name(), '', false, \phpbb\request\request_interface::COOKIE);
+
+		// Validate whether it's already added
+		$existing_values = self::split_cookie_values($existing_cookie);
+
+		if (in_array($contrib, $existing_values['contribs']) || in_array($revision, $existing_values['revisions']))
+		{
+			// This contribution (or revision) has already been added
+			$json = $this->create_json_response(false, $existing_values, $this->language->lang('PACKAGE_ALREADY_ADDED'));
+		}
+
+		else
+		{
+			// Cookies are my favourite food group, cookies taste nice. And in this case they are lightweight :D
+			$value = $contrib . '|' . $revision;
+			$cookie_value = (!empty($existing_cookie)) ? sprintf('%s,%s', $existing_cookie, $value) : $value;
+
+			// Set the cookie value; expire after an hour (plenty of time for the user to download the package)
+			$this->save_cookie($cookie_value);
+
+			$updated_values = self::split_cookie_values($cookie_value);
+			$download_link = sprintf('<a href="%s">%s</a>', $this->helper->route('phpbb.titania.package_builder.download'), $this->language->lang('PACKAGE_ADDED', count($updated_values['contribs'])));
+
+			$json = $this->create_json_response(true, $updated_values, $download_link);
+		}
+
+		return $json;
+	}
+}

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -194,6 +194,13 @@ $lang = array_merge($lang, array(
 
 	'ORDER'						=> 'Order',
 
+	'PACKAGE_ADDED'				=> array(
+		1	=> 'Download package with 1 customisation',
+		2	=> 'Download package with %d customisations',
+	),
+
+	'PACKAGE_ALREADY_ADDED'		=> 'This contribution has already been added to the package',
+
 	'PAGE_REQUEST_INVALID'		=> 'The page request is invalid. Please try again.',
 	'PARENT_CATEGORY'			=> 'Parent Category',
 	'PARENT_CONTRIBUTION'		=> 'Parent Contribution',

--- a/styles/prosilver/template/common/revision_list.html
+++ b/styles/prosilver/template/common/revision_list.html
@@ -19,7 +19,7 @@
 						<div class="list-inner">
 							{% if revisions.U_DOWNLOAD %}<a href="{{ revisions.U_DOWNLOAD }}" title="{{ lang('DOWNLOAD') }}">{% endif %}
 								{% if revisions.NAME %}{{ revisions.NAME }}{% else %}<em>{{ lang('NO_REVISION_NAME') }}</em>{% endif %}
-							{% if revisions.U_DOWNLOAD %}</a>{% endif %}
+							{% if revisions.U_DOWNLOAD %}</a>{% if revisions.S_PACKAGE %} <span class="package-builder-add"><a href="{{ revisions.U_PACKAGE_ADD }}" data-ajax="titania.package.builder.add" data-revision-id="{{ revisions.REVISION_ID }}">[+]</a></span>{% endif %}{% endif %}
 						</div>
 					</dt>
 					<dd class="general revision-status">

--- a/styles/prosilver/theme/common.css
+++ b/styles/prosilver/theme/common.css
@@ -65,6 +65,9 @@ h3.section-name {
 	text-align: left;
 }
 
+.package-builder-download-prompt {
+	font-size: 0.8em;
+}
 
 a.download-button, a.colorizeit-button {
 	box-sizing: border-box;


### PR DESCRIPTION
# Overview

This allows users to download a pre-packaged version of phpBB3 which contains extensions, language packs and styles which they have already selected within Titania.

**This package builder code is still a work in progress.** I wanted to open it up for discussion because I have a few questions which I need clarification on before proceeding further.

The general idea is that a user can go through the customisations (extensions, language packs and styles approved for v3.2) in Titania, and when they see something the like instead of downloading it standalone they can "add" it to a package. 

When they add items, it gets stored in a cookie (with an expiry of an hour). At any time after adding something, the user will be given the option of downloading the full package.

The full package will be a zip of the latest version of phpBB3, with all of the customisations the user selected automatically put into place within the folder structure.

![image](https://user-images.githubusercontent.com/2110222/66710488-3a502700-edac-11e9-8ef4-d3d685a9116f.png)

# My Questions

## Language packs

@Crizz0 Would you be able to supply the convention of where directories from a language pack need to go? For example:
 - If we unzip `Eesti-keelne-phpBB-3.2.8.zip` that creates a `Eesti-keelne-phpBB-3.2.8` directory, and within that is a `Eesti keelne phpBB 3.2.8` directory. Is that the standard format translators use, or do some put all of their files at the top level?
 - `\ext\phpbb\viglink\language\{iso}` => `\ext\phpbb\viglink\language\{iso}`
 - `\language\{iso}` => `\language\{iso}`
 - `\styles\prosilver\theme\{iso}` => `\styles\prosilver\theme\{iso}`
    - Do translators ever put theme icons for anything besides prosilver? Because we'd need to account for that if a user was to pre-package a style.

## Styles 

@phpbb-es @vinny Are there any times when style authors do something unpredictable? Any special rules I should know about when automatically copying a style into the appropriate folder within phpBB?
  - For example if I download Blackfog_3.2.8.2.zip and unzip it, a `Blackfog_3.2.8.2` will be created which contains a subfolder called `Blackfog`. Which is then copied to the `style/` directory within phpBB. Can I rely on it being that simple for every style?

## Extensions

@kasimi @VSEphpbb @DavidIQ Can you think of anything users might do inside their own extension directories which would potentially be a problem when writing rules to copy extension code out of an extension zip into a phpBB zip?

## General

Can anyone anticipate any problems by having extensions, language packs and styles already put into place within the directory structure *before* the user has installed phpBB?

# Potential problems

After unzipping the latest phpBB version (which we have inside Titania) into `/phpBB3/ext/phpbb/titania/files/contrib_temp/tmp` I noticed it creates the following error - I believe it might be a composer/autoloader issue because it's finding multiple copies of the phpBB codebase? If anyone can think of a workaround for this, some way that this directory can be ignored for composer purposes, please let me know. Ultimately we need some place on the file system where phpBB3 can be unzipped, extensions/language packs/style can be unzipped and then all of the files moved into the proper location before phpBB3 is zipped back up again, and all of the files are cleaned up.

> Whoops, looks like something went wrong.
> FatalErrorException in collection_pass.php line 24:
> Compile Error: Cannot declare class phpbb\di\pass\collection_pass, because the name is already in use
> in collection_pass.php line 24
> in class_loader.php line 160
> at class_loader->load_class() in container_builder.php line 660
> at spl_autoload_call() in container_builder.php line 660
> at class_exists() in container_builder.php line 660
> at container_builder->register_ext_compiler_pass() in container_builder.php line 180
> at container_builder->get_container() in common.php line 115
> in app.php line 23
> at {main}() in app.php line 0

## To be completed

### UI

At the moment, the only change to the UI is what I've shown above. There is a [+] button next to a revision to add that to the package, and after the AJAX call has updated the cookie that turns into a "Download package with {x} customisations" link. If the user leaves and returns to that customisation page, the plus sign will no longer be visible as a revision has already been flagged for packaging.

It might be nice if we had a new page which a user could visit that shows their selections, and gave them the ability to remove things they've added (or clear all options, which I've already added the `/package-builder/reset` route for.

If anyone has any suggestions please post them here. Just remember I have zero skills with images so anything that involves new icons might be a non-starter unless someone can make them for me :stuck_out_tongue: 

### Downloading the final zip

This is still a work in progress due to the problems mentioned above. I need to have a hard set of rules/conventions such that whenever Titania unzips an extension, language pack or style it knows what to copy and to where.

I also need to add some authorisation logic around the revision/contrib ID's before downloading so that someone can't manipulate the cookie and download a revision they don't have access to (like something unapproved).

# Status

- [x] Allow users to select customisations for pre-packing
- [x] Save selections to a cookie
- [x] Show download link for final package
- [ ] Finalise rules for packaging extensions
- [ ] Finalise rules for packaging language packs
- [ ] Finalise rules for packaging styles
- [ ] Combine all of the customisations into the package and download to the browser as a zip
- [ ] Create a new page where people can view/remove their selections and another download link

https://tracker.phpbb.com/projects/CUSTDB/issues/CUSTDB-465