### PR TITLE
Remove old unused phpbb.com hack

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -99,9 +99,6 @@ class config extends \phpbb\titania\entity\base
 			// Maximum rating allowed when rating stuff
 			'max_rating'				=> array('default' => 5),
 
-			'phpbbcom_profile'			=> array('default' => true),
-			'phpbbcom_viewprofile_url'	=> array('default' => 'https://www.phpbb.com/community/memberlist.php?mode=viewprofile&amp;u=%u'),
-
 			// Mod/style database release forums (receive announcements on updates/approval)
 			'forum_mod_database'		=> array('default' => array(
 				'30'	=> 0,
@@ -367,8 +364,6 @@ class config extends \phpbb\titania\entity\base
 //			'upload_directory'				=> 'array|string',
 
 			// Not going to support these in the admin panel
-//			'phpbbcom_profile'
-//			'phpbbcom_viewprofile_url'
 //			'upload_allowed_extensions'
 //			'mpv_server_list'
 //			'phpbb_versions'

--- a/includes/objects/author.php
+++ b/includes/objects/author.php
@@ -68,7 +68,6 @@ class titania_author extends \phpbb\titania\entity\message_base
 		$this->object_config = array_merge($this->object_config, array(
 			'author_id'				=> array('default' => 0),
 			'user_id'				=> array('default' => 0),
-			'phpbb_user_id'			=> array('default' => 0),
 
 			'author_website'		=> array('default' => '',	'max' => 200),
 			'author_rating'			=> array('default' => 0.0),

--- a/includes/objects/author.php
+++ b/includes/objects/author.php
@@ -252,21 +252,6 @@ class titania_author extends \phpbb\titania\entity\message_base
 	}
 
 	/**
-	 * Get phpBB.com profile url
-	 *
-	 * @return string
-	 */
-	public function get_phpbb_com_profile_url()
-	{
-		if (titania::$config->phpbbcom_profile && $this->phpbb_user_id)
-		{
-			return sprintf(titania::$config->phpbbcom_viewprofile_url, $this->phpbb_user_id);
-		}
-
-		return '';
-	}
-
-	/**
 	 * Get correct website url
 	 *
 	 * @return string
@@ -309,7 +294,6 @@ class titania_author extends \phpbb\titania\entity\message_base
 
 			'U_AUTHOR_PROFILE'				=> $this->get_url(),
 			'U_AUTHOR_PROFILE_PHPBB'		=> $this->get_phpbb_profile_url(),
-			'U_AUTHOR_PROFILE_PHPBB_COM'	=> $this->get_phpbb_com_profile_url(),
 			'U_AUTHOR_CONTRIBUTIONS'		=> $this->get_url('contributions'),
 		);
 

--- a/migrations/drop_phpbb_user_id.php
+++ b/migrations/drop_phpbb_user_id.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Customisation Database package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\titania\migrations;
+
+class drop_phpbb_user_id extends base
+{
+	public static function depends_on()
+	{
+		return array('\phpbb\titania\migrations\release_1_1_0');
+	}
+
+	public function effectively_installed()
+	{
+		$table_prefix = $this->get_titania_table_prefix();
+
+		return !$this->db_tools->sql_column_exists($table_prefix . 'authors', 'phpbb_user_id');
+	}
+
+	public function update_schema()
+	{
+		$table_prefix = $this->get_titania_table_prefix();
+
+		return array(
+			'drop_columns' => array(
+				$table_prefix . 'authors' => array('phpbb_user_id'),
+			),
+		);
+	}
+
+	public function revert_schema()
+	{
+		$table_prefix = $this->get_titania_table_prefix();
+
+		return array(
+			'add_columns' => array(
+				$table_prefix . 'authors' => array(
+					'phpbb_user_id' => array('UINT', 0),
+				),
+			),
+		);
+	}
+}

--- a/styles/prosilver/template/authors/author_details.html
+++ b/styles/prosilver/template/authors/author_details.html
@@ -12,11 +12,6 @@
 				<li>
 					<strong>{{ lang('AUTHOR') }}</strong> {{ USER_FULL }}
 				</li>
-				{% if U_AUTHOR_PROFILE_PHPBB_COM %}
-				<li>
-					<strong>{{ lang('PHPBB_PROFILE') }}</strong> <a href="{{ U_AUTHOR_PROFILE_PHPBB_COM }}">{{ lang('VIEW') }}</a>
-				</li>
-				{% endif %}
 				{% if AUTHOR_WEBSITE %}
 				<li>
 					<strong>{{ lang('WEBSITE') }}</strong> {{ AUTHOR_WEBSITE_LINK }}


### PR DESCRIPTION
I found this hardcoded phpbb.com setting in titania itself. It’s 12 year old code and does not even appear to be in use anyway (on phpbb.com).

It also seemed to have a specific `phpbb_user_id` field in addition to the normal `user_id`. I can't see how it's used anywhere except as part of this little hack, which from the template usage, does not even appear to be in use on phpbb.com.

So I'm removing all of it. But am curious to know what was actually being stored in the `phpbb_user_id` field, if anything at all? Is it just `0` or is it the same as the `user_id` or something totally different?