### PR TITLE
Support characters in extension display name that are HTML-entity-encoded

### DIFF
--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -267,7 +267,7 @@ class type extends base
 		{
 			throw new \Exception('UNSTABLE_COMPOSER_VERSION');
 		}
-		if ($data['extra']['display-name'] !== $contrib->contrib_name)
+		if ($data['extra']['display-name'] !== htmlspecialchars_decode($contrib->contrib_name, ENT_COMPAT))
 		{
 			throw new \Exception($this->user->lang('MISMATCH_DISPLAY_NAME', $data['extra']['display-name'], $contrib->contrib_name));
 		}


### PR DESCRIPTION
For example, for an extension display name `A & B`, `$data['extra']['display-name']` is `A & B` (as loaded from `composer.json`) but  `$contrib->contrib_name` is `A &amp; B` so the comparison fails.

I'm using `ENT_COMPAT` because that's what the `$request->variable()` method passes to `htmlspecialchars()` when fetching the value.