### PR TITLE
[CUSTDB-799] Quote post text when sending PM from Titania

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -210,10 +210,13 @@ services:
     phpbb.titania.listener:
         class: phpbb\titania\event\main_listener
         arguments:
+            - '@request'
             - '@dbal.conn'
             - '@user'
             - '@template'
             - '@phpbb.titania.controller.helper'
+            - '@phpbb.titania.access'
+            - '@phpbb.titania.contribution.type.collection'
             - '%core.root_path%'
             - '%phpbb.titania.root_path%'
             - '%core.php_ext%'

--- a/includes/overlords/posts.php
+++ b/includes/overlords/posts.php
@@ -353,7 +353,7 @@ $limit_topic_days = array(0 => $user->lang['ALL_TOPICS'], 1 => $user->lang['1_DA
 				array(
 					'ID'		=> 'pm',
 					'NAME' 		=> phpbb::$user->lang['SEND_PRIVATE_MESSAGE'],
-					'U_CONTACT'	=> users_overlord::get_user($post->post_user_id, '_u_pm'),
+					'U_CONTACT'	=> users_overlord::get_user($post->post_user_id, '_u_pm') . '&amp;titania_msg_id=' . $post->post_id,
 				),
 				array(
 					'ID'		=> 'email',


### PR DESCRIPTION
This change means when someone clicks the PM button for a poster in a Titania support topic, it quotes the post like it does in the main forums.

These are the tests I ran, obviously the logic around checking access level is the key part of this because we don't want people to be able to just guess a post id and put it in the URL to see something that's private.

|  | Public | Author | Teams
| ------------- | ------------- | ------------- | ------------- |
| Quoting a public post | CAN SEND | CAN SEND | CAN SEND
| Quoting a authors-only post | CANNOT SEND | CAN SEND | CAN SEND
| Quoting a teams-only post | CANNOT SEND | CANNOT SEND | CAN SEND

Screenshot:

![Screen Shot 2020-07-01 at 1 15 35 PM](https://user-images.githubusercontent.com/2110222/86205676-0c5e7d00-bb9d-11ea-863e-eb885059190d.png)

https://tracker.phpbb.com/projects/CUSTDB/issues/CUSTDB-799