### PR TITLE
[CUSTDB-800] Show unauthorised message if user cannot view create page

### DIFF
--- a/controller/author.php
+++ b/controller/author.php
@@ -353,8 +353,9 @@ class author
 	*/
 	protected function create()
 	{
-		if (!$this->is_owner && !$this->auth->acl_get('u_titania_contrib_submit'))
+		if (!$this->auth->acl_get('u_titania_contrib_submit'))
 		{
+			// Show the unauthorised page if the user has insufficient permissions
 			return $this->helper->needs_auth();
 		}
 


### PR DESCRIPTION
Fix a permissions bug on the create page. Even if the `u_titania_contrib_submit` permission was set to "no", a faulty `if` statement was letting it through. More information is available on the ticket at https://tracker.phpbb.com/projects/CUSTDB/issues/CUSTDB-800

Now if a user without permission views the page, they will see the standard unauthorised message.

![800](https://user-images.githubusercontent.com/2110222/89030175-7e73de80-d362-11ea-92ab-a55d326a8b66.png)




