### PR TITLE
[CUSTDB-804] Better handling of user delete

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -214,6 +214,7 @@ services:
             - '@dbal.conn'
             - '@user'
             - '@template'
+            - '@language'
             - '@phpbb.titania.controller.helper'
             - '@phpbb.titania.access'
             - '@phpbb.titania.contribution.type.collection'

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -448,7 +448,7 @@ class main_listener implements EventSubscriberInterface
 		$this->delete_user_contribs_with_unapproved_revisions($event_data);
 
 		// Delete Titania topics and posts by the user(s)
-		if ($event_data['mode'] === 'remove')
+		if ($event_data['mode'] === 'remove' || $event_data['mode'] == 'retain')
 		{
 			// Handle the topics
 			$this->delete_user_titania_topics($event_data);
@@ -456,9 +456,6 @@ class main_listener implements EventSubscriberInterface
 			// Handle the posts
 			$this->delete_user_titania_posts($event_data);
 		}
-
-// TODO: remove debug code
-die('-- STOP HERE --');
 	}
 
 	/**
@@ -505,9 +502,6 @@ die('-- STOP HERE --');
 					$contrib->delete();
 				}
 			}
-
-// TODO: remove debug code
-echo $contrib_id . ': '. $approved_revisions . '<br />';
 		}
 
 		$this->db->sql_freeresult($result);
@@ -523,7 +517,8 @@ echo $contrib_id . ': '. $approved_revisions . '<br />';
 		$topic = new \titania_topic();
 
 		$sql = 'SELECT * FROM ' . TITANIA_TOPICS_TABLE . '
-				WHERE ' . $this->db->sql_in_set('topic_first_post_user_id', $event_data['user_ids']);
+				WHERE ' . $this->db->sql_in_set('topic_first_post_user_id', $event_data['user_ids']) . '
+				AND topic_type = ' . ext::TITANIA_SUPPORT;
 
 		$result = $this->db->sql_query($sql);
 
@@ -547,7 +542,8 @@ echo $contrib_id . ': '. $approved_revisions . '<br />';
 		$post = new \titania_post();
 
 		$sql = 'SELECT * FROM ' . TITANIA_POSTS_TABLE . '
-				WHERE ' . $this->db->sql_in_set('post_user_id', $event_data['user_ids']);
+				WHERE ' . $this->db->sql_in_set('post_user_id', $event_data['user_ids']) . '
+				AND post_type = ' . ext::TITANIA_SUPPORT;
 
 		$result = $this->db->sql_query($sql);
 

--- a/language/en/info_acp_titania.php
+++ b/language/en/info_acp_titania.php
@@ -27,6 +27,8 @@ if (empty($lang) || !is_array($lang))
 
 // Merge the following language entries into the lang array
 $lang = array_merge($lang, array(
+	'CONFIRM_DELETE_USER_OPERATION'		=> 'This will also remove all Customisation Database posts, topics and unapproved contributions submitted by this user.',
+
 	'ROLE_TITANIA_MODIFICATION_TEAM'	=> 'Titania Modifications Team Role',
 	'ROLE_TITANIA_STYLE_TEAM'			=> 'Titania Style Team Role',
 	'ROLE_TITANIA_MODERATOR_TEAM'		=> 'Titania Moderation Team Role',


### PR DESCRIPTION
I wanted to create a draft PR of this change because there's more visibility on GitHub rather than JIRA, so a bit easier to discuss changes. I still want to do more testing on this too, more on that below.

The basic idea behind this change, is that when a user is deleted in phpBB we will also handle their data removal in Titania:

* Completely remove any contributions submitted by the user that don't have an approved revision
* Delete Titania support topics created by the user
* Delete Titania support posts created by the user

When deleting a user in phpBB, there will also be a message to indicate Titania data will be affected (I couldn't find an event to put the same message for pruning users unfortunately):

![image](https://user-images.githubusercontent.com/2110222/89123220-4e624200-d500-11ea-96b3-6e3ec279c7a5.png)

## My questions

1. Do we want any restrictions on the Titania posts/topics that are removed? I've currently restricted it to support topics, because I feel like we should be keeping the queue discussion topic if we have a contribution with an approved revision.

2. Should we be deleting topics made by the user? What if they posted something which generated an important conversation?

3. Should we respect the retain/remove flags from phpBB when considering whether to delete Titania posts/topics? [At the moment](https://github.com/battye/customisation-db/blob/9d670ad1fde64156729035d92551084059ae6899/event/main_listener.php#L451) I've just got it to delete from Titania regardless, but it's easy to change it so that it only does that if "remove" is selected in phpBB.

4. I'm worried about these 2 SQL queries: [delete topics sql](https://github.com/battye/customisation-db/blob/9d670ad1fde64156729035d92551084059ae6899/event/main_listener.php#L519) and [delete posts sql](https://github.com/battye/customisation-db/blob/9d670ad1fde64156729035d92551084059ae6899/event/main_listener.php#L544)
My eyes might have been deceiving me (it was late when I was testing yesterday 😛) but I think I saw an example where a topic created by another user (but replied to by the user I was deleting) ended up being removed. So I'm worried there's some logic behind `topic_first_post_user_id` that I'm unaware of; or perhaps something funny in `$topic->delete()`. I couldn't replicate the problem when I tried it today, all the posts and topics being removed were as I expected. But nonetheless I want to test that area some more, and I'm hopeful someone else might have an idea of what might have happened.

https://tracker.phpbb.com/browse/CUSTDB-804