### PR TITLE
Store array based configs in config_text table

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -20,6 +20,9 @@ class config extends \phpbb\titania\entity\base
 	/** @var \phpbb\config\config */
 	protected $config;
 
+	/** @var \phpbb\config\db_text */
+	protected $config_text;
+
 	/** @var string */
 	protected $ext_root_path;
 
@@ -29,13 +32,15 @@ class config extends \phpbb\titania\entity\base
 	/**
 	 * Constructor.
 	 *
-	 * @param \phpbb\config\config $config
-	 * @param string $ext_root_path
-	 * @param string $php_ext
+	 * @param \phpbb\config\config  $config
+	 * @param \phpbb\config\db_text $config_text
+	 * @param string                $ext_root_path
+	 * @param string                $php_ext
 	 */
-	public function __construct(\phpbb\config\config $config, $ext_root_path, $php_ext)
+	public function __construct(\phpbb\config\config $config, \phpbb\config\db_text $config_text, $ext_root_path, $php_ext)
 	{
 		$this->config = $config;
+		$this->config_text = $config_text;
 		$this->ext_root_path = $ext_root_path;
 		$this->php_ext = $php_ext;
 
@@ -289,7 +294,12 @@ class config extends \phpbb\titania\entity\base
 
 		foreach ($this->get_configurables() as $config => $type)
 		{
-			if ($this->config->offsetExists(ext::TITANIA_CONFIG_PREFIX . $config))
+			if (strpos($type, 'array') === 0 && $config_text = $this->config_text->get(ext::TITANIA_CONFIG_PREFIX . $config))
+			{
+				$configs[$config] = json_decode($config_text, true);
+			}
+
+			else if ($this->config->offsetExists(ext::TITANIA_CONFIG_PREFIX . $config))
 			{
 				$configs[$config] = json_decode($this->config->offsetGet(ext::TITANIA_CONFIG_PREFIX . $config), true);
 			}

--- a/config/controllers.yml
+++ b/config/controllers.yml
@@ -388,6 +388,7 @@ services:
         arguments:
             - '@auth'
             - '@config'
+            - '@config_text'
             - '@dbal.conn'
             - '@template'
             - '@user'

--- a/config/services.yml
+++ b/config/services.yml
@@ -132,6 +132,7 @@ services:
         class: phpbb\titania\config\config
         arguments:
             - '@config'
+            - '@config_text'
             - '%phpbb.titania.root_path%'
             - '%core.php_ext%'
 

--- a/controller/manage/config_settings.php
+++ b/controller/manage/config_settings.php
@@ -19,6 +19,9 @@ use phpbb\titania\ext;
 
 class config_settings extends base
 {
+	/** @var \phpbb\config\db_text */
+	protected $config_text;
+
 	/** @var \phpbb\group\helper $group_helper */
 	protected $group_helper;
 
@@ -28,26 +31,28 @@ class config_settings extends base
 	/**
 	 * Constructor
 	 *
-	 * @param \phpbb\auth\auth $auth
-	 * @param \phpbb\config\config $config
+	 * @param \phpbb\auth\auth                  $auth
+	 * @param \phpbb\config\config              $config
+	 * @param \phpbb\config\db_text             $config_text
 	 * @param \phpbb\db\driver\driver_interface $db
-	 * @param \phpbb\template\template $template
-	 * @param \phpbb\user $user
-	 * @param \phpbb\titania\cache\service $cache
-	 * @param \phpbb\titania\controller\helper $helper
-	 * @param type_collection $types
-	 * @param \phpbb\request\request $request
-	 * @param \phpbb\titania\config\config $ext_config
-	 * @param \phpbb\titania\display $display
-	 * @param \phpbb\titania\message\message $message
-	 * @param \phpbb\group\helper $group_helper
+	 * @param \phpbb\template\template          $template
+	 * @param \phpbb\user                       $user
+	 * @param \phpbb\titania\cache\service      $cache
+	 * @param \phpbb\titania\controller\helper  $helper
+	 * @param type_collection                   $types
+	 * @param \phpbb\request\request            $request
+	 * @param \phpbb\titania\config\config      $ext_config
+	 * @param \phpbb\titania\display            $display
+	 * @param \phpbb\titania\message\message    $message
+	 * @param \phpbb\group\helper               $group_helper
 	 */
-	public function __construct(\phpbb\auth\auth $auth, \phpbb\config\config $config, \phpbb\db\driver\driver_interface $db, \phpbb\template\template $template, \phpbb\user $user, \phpbb\titania\cache\service $cache, \phpbb\titania\controller\helper $helper, type_collection $types, \phpbb\request\request $request, \phpbb\titania\config\config $ext_config, \phpbb\titania\display $display, \phpbb\titania\message\message $message, \phpbb\group\helper $group_helper)
+	public function __construct(\phpbb\auth\auth $auth, \phpbb\config\config $config, \phpbb\config\db_text $config_text, \phpbb\db\driver\driver_interface $db, \phpbb\template\template $template, \phpbb\user $user, \phpbb\titania\cache\service $cache, \phpbb\titania\controller\helper $helper, type_collection $types, \phpbb\request\request $request, \phpbb\titania\config\config $ext_config, \phpbb\titania\display $display, \phpbb\titania\message\message $message, \phpbb\group\helper $group_helper)
 	{
 		parent::__construct($auth, $config, $db, $template, $user, $cache, $helper, $types, $request, $ext_config, $display);
 
 		$this->message = $message;
 		$this->group_helper = $group_helper;
+		$this->config_text = $config_text;
 	}
 
 	/**
@@ -116,13 +121,15 @@ class config_settings extends base
 				{
 					$value[$key] = $this->request->variable($config . '_' . $key, $this->get_default($type[1]));
 				}
+				$this->config_text->set(ext::TITANIA_CONFIG_PREFIX . $config, json_encode($value));
+				$this->config->delete(ext::TITANIA_CONFIG_PREFIX . $config); // delete it from config if its still there for any reason
 			}
 			else
 			{
 				$value = $this->request->variable($config, $this->get_default($type));
+				$this->config->set(ext::TITANIA_CONFIG_PREFIX . $config, json_encode($value));
 			}
 
-			$this->config->set(ext::TITANIA_CONFIG_PREFIX . $config, json_encode($value));
 			$this->ext_config->__set($config, $value);
 		}
 	}


### PR DESCRIPTION
So with this, you would need to go to the Administration->Configuration Settings and just submit the form once. That will restore settings, and move the more complex array based settings from config to config_text.