### PR TITLE
Bug fix to show unapproved icon on topics list

### DIFF
--- a/styles/prosilver/template/common/topic_list.html
+++ b/styles/prosilver/template/common/topic_list.html
@@ -70,7 +70,7 @@
 							</a>
 						{% endif %}
 						<a href="{{ topics.U_VIEW_TOPIC }}" class="topictitle">{{ topics.TOPIC_SUBJECT }}</a>{% if topics.TOPIC_CONTRIB_NAME %}<br /><em>{% if topics.CONTRIB_TYPE %}{{ topics.CONTRIB_TYPE }}{% endif %} {% if topics.U_VIEW_TOPIC_CONTRIB %} &raquo; <a href="{{ topics.U_VIEW_TOPIC_CONTRIB }}">{{ topics.TOPIC_CONTRIB_NAME }}</a>{% else %} &raquo; {{ topics.TOPIC_CONTRIB_NAME }}{% endif %} {% if topics.U_VIEW_TOPIC_CONTRIB_SUPPORT %} &raquo; <a href="{{ topics.U_VIEW_TOPIC_CONTRIB_SUPPORT }}">{{ lang('CONTRIB_SUPPORT') }}</a>{% else %} &raquo; {{ topics.TOPIC_CONTRIB_NAME }}{% endif %}</em>{% endif %}
-						{% if not topics.TOPIC_APPROVED or not topics.POSTS_APPROVED %}<i class="icon fa-question fa-fw icon-blue" aria-hidden="true"></i><span class="sr-only">{{ lang('TOPIC_UNAPPROVED') }}</span> {% endif %}
+						{% if not topics.TOPIC_APPROVED or not topics.POSTS_APPROVED %}<i class="icon fa-question fa-fw icon-blue" aria-hidden="true"></i><span class="sr-only">{{ lang('POSTS_UNAPPROVED') }}</span> {% endif %}
 						{% if topics.TOPIC_REPORTED %}<i class="icon fa-exclamation fa-fw icon-red" aria-hidden="true"></i><span class="sr-only">{{ lang('TOPIC_REPORTED') }}</span>{% endif %}<br />
 						{% if topics.pagination|length %}
 						<div class="pagination">

--- a/styles/prosilver/template/common/topic_list.html
+++ b/styles/prosilver/template/common/topic_list.html
@@ -70,7 +70,7 @@
 							</a>
 						{% endif %}
 						<a href="{{ topics.U_VIEW_TOPIC }}" class="topictitle">{{ topics.TOPIC_SUBJECT }}</a>{% if topics.TOPIC_CONTRIB_NAME %}<br /><em>{% if topics.CONTRIB_TYPE %}{{ topics.CONTRIB_TYPE }}{% endif %} {% if topics.U_VIEW_TOPIC_CONTRIB %} &raquo; <a href="{{ topics.U_VIEW_TOPIC_CONTRIB }}">{{ topics.TOPIC_CONTRIB_NAME }}</a>{% else %} &raquo; {{ topics.TOPIC_CONTRIB_NAME }}{% endif %} {% if topics.U_VIEW_TOPIC_CONTRIB_SUPPORT %} &raquo; <a href="{{ topics.U_VIEW_TOPIC_CONTRIB_SUPPORT }}">{{ lang('CONTRIB_SUPPORT') }}</a>{% else %} &raquo; {{ topics.TOPIC_CONTRIB_NAME }}{% endif %}</em>{% endif %}
-						{% if not topics.TOPIC_APPROVED or not topics.POSTS_APPROVED %}{{ topics.UNAPPROVED_IMG }} {% endif %}
+						{% if not topics.TOPIC_APPROVED or not topics.POSTS_APPROVED %}<i class="icon fa-question fa-fw icon-blue" aria-hidden="true"></i><span class="sr-only">{{ lang('TOPIC_UNAPPROVED') }}</span> {% endif %}
 						{% if topics.TOPIC_REPORTED %}<i class="icon fa-exclamation fa-fw icon-red" aria-hidden="true"></i><span class="sr-only">{{ lang('TOPIC_REPORTED') }}</span>{% endif %}<br />
 						{% if topics.pagination|length %}
 						<div class="pagination">


### PR DESCRIPTION
Noticed by @Crizz0, there was a bug on the Titania topics list whereby the question mark icon to show that there's unapproved posts wasn't appearing. 

Now it works correctly again:

![image](https://user-images.githubusercontent.com/2110222/140631687-52014278-b67b-4a39-9567-e593b61dbacf.png)
