### PR TITLE
Add missing lang key

### DIFF
--- a/language/en/search.php
+++ b/language/en/search.php
@@ -42,6 +42,8 @@ $lang = array_merge($lang, array(
 	'CONTRIB_NAME_DESCRIPTION'		=> 'Contribution Name and Description',
 	'CONTRIB_SUPPORT'				=> 'Contribution Discussion/Support',
 
+	'NO_SEARCH_TERMS'				=> 'No search terms have been entered.',
+
 	'SEARCH_KEYWORDS_EXPLAIN'		=> 'Put a list of words separated by <strong>|</strong> into brackets if only one of the words must be found. Use * as a wildcard for partial matches.',
 	'SEARCH_MSG_ONLY'				=> 'Text/Description only',
 	'SEARCH_SUBCATEGORIES'			=> 'Search Subcategories',


### PR DESCRIPTION
The lang key [NO_SEARCH_TERMS](https://github.com/phpbb/customisation-db/blob/3.2.x/controller/search.php#L242) doesn't exist.

Usage context:
Make a search with no keywords.
=> https://www.phpbb.com/customise/db/find-contribution/results?keywords=&c%5B%5D=0&sc=1