### PR TITLE
Improper escaping of command arguments on Windows leading to command injection 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -180,7 +180,7 @@
             "time": "2021-01-12T12:10:35+00:00"
         },
         {
-            "name": "composer/composer",
+            "name": "composer/composer", //  upgrade this for fixed
             "version": "1.10.22",
             "source": {
                 "type": "git",


### PR DESCRIPTION
## Describe the bugs: 🐛
Composer is an open source dependency manager for the PHP language. In affected versions windows users running Composer to install untrusted dependencies are subject to command injection and should upgrade their composer version. Other OSs and WSL are not affected. The issue has been resolved in composer versions 1.10.23 and 2.1.9. There are no workarounds for this issue.

## Recomendation References
https://github.com/composer/composer/releases/tag/1.10.23
[CVE-2021-41116](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41116)
[Github-Advisories](https://github.com/composer/composer/security/advisories/GHSA-frqg-7g38-6gcf)
`CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:L/A:N`