### PR TITLE
Titania in GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+# Debian version
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+# Install PHP
+RUN apt-get -y update
+RUN apt-get -y install php php-xml php-mbstring php-curl php-zip php-xdebug
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Install MySQL
+RUN apt-get -y install mysql-server php-mysql
+
+# Xdebug
+ADD resources/xdebug.ini /etc/php/8.1/apache2/conf.d/xdebug.ini
+
+# Configure Apache
+RUN echo "Listen 8080" >> /etc/apache2/ports.conf && \
+    a2enmod rewrite

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.1/containers/ubuntu
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
+		// Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
+		"args": { "VARIANT": "ubuntu-22.04" }
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {
+				// Allow Xdebug to listen to requests from remote (or container)
+				"remote.localPortHost": "allInterfaces"
+			},
+			//"devPort": {},
+			// Specify which VS Code extensions to install (List of IDs)
+			"extensions": ["xdebug.php-debug"]
+			}
+		},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [80, 9003],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postStartCommand": "bash .devcontainer/resources/setup.sh",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"github-cli": "latest"
+	}
+}

--- a/.devcontainer/resources/phpbb-config.yml
+++ b/.devcontainer/resources/phpbb-config.yml
@@ -1,0 +1,38 @@
+installer:
+    admin:
+        name: admin
+        password: adminadmin
+        email: admin@example.org
+
+    board:
+        lang: en
+        name: My Board
+        description: My amazing new phpBB board (Titania)
+
+    database:
+        dbms: mysqli
+        dbhost: 127.0.0.1
+        dbport: 3306
+        dbuser: phpbb
+        dbpasswd: phpbb
+        dbname: phpbb
+        table_prefix: phpbb_
+
+    email:
+        enabled: false
+        smtp_delivery : ~
+        smtp_host: ~
+        smtp_port: ~
+        smtp_auth: ~
+        smtp_user: ~
+        smtp_pass: ~
+
+    server:
+        cookie_secure: false
+        server_protocol: http://
+        force_server_vars: false
+        server_name: localhost
+        server_port: 80
+        script_path: /
+
+    extensions: ['phpbb/titania']

--- a/.devcontainer/resources/setup.sh
+++ b/.devcontainer/resources/setup.sh
@@ -1,0 +1,44 @@
+# Copy Apache configuration
+# sudo rm /etc/apache2/sites-enabled/000-default.conf
+# sudo cp .devcontainer/resources/phpbb-apache.conf /etc/apache2/sites-enabled/000-default.conf
+
+# Start MySQL
+sudo service mysql start
+
+# Start Apache
+sudo service apache2 start
+
+# Add SSH key
+echo "$SSH_KEY" > /home/vscode/.ssh/id_rsa && chmod 600 /home/vscode/.ssh/id_rsa
+
+# Create a MySQL user to use
+sudo mysql -u root<<EOFMYSQL
+    CREATE USER 'phpbb'@'localhost' IDENTIFIED BY 'phpbb'; 
+    GRANT ALL PRIVILEGES ON *.* TO 'phpbb'@'localhost' WITH GRANT OPTION;
+    CREATE DATABASE IF NOT EXISTS phpbb;
+EOFMYSQL
+
+# Download dependencies
+echo "Dependencies"
+composer install --no-interaction
+
+# Install phpBB
+echo "phpBB project"
+composer create-project --no-interaction phpbb/phpbb /workspaces/phpbb
+
+# Copy phpBB config
+echo "Copy phpBB config"
+cp /workspaces/customisation-db/.devcontainer/resources/phpbb-config.yml /workspaces/phpbb/install/install-config.yml
+
+echo "Symlink extension"
+sudo rm -rf /var/www/html
+sudo ln -s /workspaces/phpbb /var/www/html
+mkdir /workspaces/phpbb/ext/phpbb
+sudo ln -s /workspaces/customisation-db /workspaces/phpbb/ext/phpbb/titania
+
+echo "phpBB CLI install"
+cd /workspaces/phpbb && composer install --no-interaction
+sudo php /workspaces/phpbb/install/phpbbcli.php install /workspaces/phpbb/install/install-config.yml
+rm -rf /workspaces/phpbb/install 
+
+echo "Completed"

--- a/.devcontainer/resources/xdebug.ini
+++ b/.devcontainer/resources/xdebug.ini
@@ -1,0 +1,11 @@
+
+zend_extension=xdebug.so
+
+[xdebug]
+xdebug.mode=develop,debug
+xdebug.discover_client_host=1
+xdebug.client_port=9003
+xdebug.start_with_request=yes
+xdebug.log='/var/log/xdebug/xdebug.log'
+xdebug.connect_timeout_ms=2000
+xdebug.idekey=VSCODE

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/var/www/html/ext/phpbb/titania": "${workspaceRoot}/"
+            },
+            "log": true
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "php.debug.ideKey": "VSCODE"
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ If you have a translation please read the information on patches.
 
 You can get involved by reporting bugs in the bug tracker (see below) and providing patches/improvements (see above).
 
+### Codespaces
+
+This project can be run in GitHub Codespaces by following the link under port 80 in the `Ports` tab and then navigating to `/app.php/db` in the browser. 
+
+If you run Titania in GitHub Codespaces, make sure to update the server name in ACP -> Server Settings -> Domain Name to match the Codespaces URL. Set `Force server URL settings` to `Yes`.
+
 ## Bug Tracker
 
 If you find a bug, please submit it to the [Customisations Database](https://github.com/phpbb/customisation-db/issues) bug tracker.

--- a/controller/helper.php
+++ b/controller/helper.php
@@ -131,7 +131,9 @@ class helper extends \phpbb\controller\helper
 	{
 		$route = parent::route($route, $params, $is_amp, $session_id, $reference_type);
 
-		return ($this->config->offsetGet('cookie_secure') && strpos($route, 'http://') === 0) ? 'https://' . substr($route, 7) : $route;
+		$full_route = ($this->config->offsetGet('cookie_secure') && strpos($route, 'http://') === 0) ? 'https://' . substr($route, 7) : $route;
+
+		return $this->get_real_url($full_route);
 	}
 
 	/**

--- a/controller/manage/manage.php
+++ b/controller/manage/manage.php
@@ -29,7 +29,7 @@ class manage extends base
 		{
 			if ($page['auth'])
 			{
-				redirect($page['url']);
+				redirect($page['url'], false, true);
 			}
 		}
 

--- a/styles/all/template/event/overall_header_head_append.html
+++ b/styles/all/template/event/overall_header_head_append.html
@@ -1,5 +1,5 @@
 {% if S_IN_TITANIA %}
-	{% INCLUDECSS '@phpbb_titania/stylesheet.css' %}
+	{% INCLUDECSS T_TITANIA_THEME_PATH ~ '/stylesheet.css' %}
 	{% if S_PLUPLOAD_EXT %}
 		{% INCLUDECSS T_THEME_PATH ~ '/plupload.css?assets_version=' ~ T_ASSETS_VERSION %}
 	{% endif %}


### PR DESCRIPTION
This could be useful for collaboration and the PHP 8 upgrade.

Ideas welcome for this. The setup is always the most frustrating part of Titania; with Codespaces we can have a single, reliable setup process.

Still to do:

* Currently the Force Server URL has to be switched on manually in the ACP. If there's a way to figure out the Codespaces URL (it's auto-generated by GitHub, so this may be difficult) we could pre-populate the config table with the server name.
  * I've put a note in the README in the meantime
  * I will play around with this some more, maybe leaving localhost out of phpbb-config.yml will allow it to work as well
* Could add some SQL to automatically give administrators all the Titania permissions.
* Maybe we could put dummy data in (obfuscated sql import? probably nothing we can do about dummy file downloads though) because it's a blank install currently
* mod_rewrite to get app.php out of the URL... maybe not necessary though