### PR TITLE
Fix link for tag in breadcrumbs

### DIFF
--- a/controller/manage/queue/item.php
+++ b/controller/manage/queue/item.php
@@ -85,6 +85,11 @@ class item extends \phpbb\titania\controller\manage\base
 			return $this->helper->needs_auth();
 		}
 
+		// Create type link information for tags (e.g., make sure the tag hyperlinks back to the type)
+		$queue_type = $this->types->get($this->queue->queue_type);
+		$queue_type_name = $queue_type->name;
+		$queue_type_url = $queue_type->url;
+
 		// Display the main queue item
 		$data = \queue_overlord::display_queue_item($this->id);
 
@@ -96,11 +101,14 @@ class item extends \phpbb\titania\controller\manage\base
 
 		$tag = $this->request->variable('tag', 0);
 
+		// Make sure the item category is added to the breadcrumb.
+		// If the user clicks on a tag (e.g., a tag like "New" or "All")
+		// then this part ensures it gets added to the navigation breadcrumbs
 		if ($tag)
 		{
 			// Add tag to Breadcrumbs
 			$this->display->generate_breadcrumbs(array(
-				$this->tags->get_tag_name($tag)	=> $this->queue->get_url(false, array('tag' => $tag)),
+				$this->tags->get_tag_name($tag)	=> $this->queue->get_url(false, array('tag' => $tag), [$queue_type_name => $queue_type_url]),
 			));
 		}
 

--- a/controller/manage/queue/queue.php
+++ b/controller/manage/queue/queue.php
@@ -90,6 +90,7 @@ class queue extends \phpbb\titania\controller\manage\base
 
 		// Add to Breadcrumbs
 		$this->display->generate_breadcrumbs(array(
+			// This is where the type gets displayed
 			$this->type->lang['lang'] => $this->get_queue_url($this->type->id),
 		));
 

--- a/includes/objects/queue.php
+++ b/includes/objects/queue.php
@@ -668,20 +668,35 @@ class titania_queue extends \phpbb\titania\entity\message_base
 	*
 	* @param bool|string $action	Optional action to link to.
 	* @param array $params			Optional parameters to add to URL.
+	* @param array $tag			Optional link to type if tags shown
 	*
 	* @return string Returns generated URL.
 	*/
-	public function get_url($action = false, $params = array())
+	public function get_url($action = false, $params = array(), $tag = false)
 	{
-		$controller = 'phpbb.titania.queue.item';
-		$params += array(
-			'id'	=> $this->queue_id,
-		);
-
-		if ($action)
+		if (!$tag)
 		{
-			$controller .= '.action';
-			$params['action'] = $action;
+			$controller = 'phpbb.titania.queue.item';
+			$params += array(
+				'id'	=> $this->queue_id,
+			);
+
+			if ($action)
+			{
+				$controller .= '.action';
+				$params['action'] = $action;
+			}
+		}
+
+		else 
+		{
+			// Link back to the correct type if the tag is shown
+			$type_name = array_key_first($tag);
+
+			$controller = 'phpbb.titania.queue.type';
+			$params += [
+				'queue_type' => $tag[$type_name],
+			];
 		}
 
 		return $this->controller_helper->route($controller, $params);


### PR DESCRIPTION
@DavidIQ Can I confirm I understand correctly what you had raised on chat?

This fix ensures that in the validation queue, if you go into a particular type (e.g., extensions) and then click on one of the subcategories (e.g., a tag like "New"), when you click on the queue item (e.g., Digital Clock in the example below) the breadcrumbs were generating with the wrong link.

Previously, the tag ("New") was linking to the item instead of back the queue type.

With this change, the tag ("New") in the breadcrumb links back to the extensions type list with the tag to filter it by New.

![Screenshot 2024-01-29 at 4 34 34 pm](https://github.com/phpbb/customisation-db/assets/2110222/ada71fd7-c8d7-4d97-8959-23031c011c8a)
