### PR TITLE
Fix issue with images in extension descriptions

### DIFF
--- a/styles/prosilver/theme/common.css
+++ b/styles/prosilver/theme/common.css
@@ -168,6 +168,10 @@ a.download-button .vendor-version {
 	position: relative;
 }
 
+.contrib-description img {
+	max-width: 100%;
+}
+
 .contrib-description dt, h3.details-heading {
 	color: #536482;
 	font-family: Verdana, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Images that are placed inside extension descriptions overflow the description area and hang off the side of the page. This is kind of a rare bug due to the fact not many people put images in the descriptions.

This is what it looks like on mobile (broken):
![phpbb-cdb-ext-desc-bug](https://github.com/phpbb/customisation-db/assets/8491069/306a3ab7-5739-41ea-ad77-af0c16004ea2)

This is what it looks like on mobile (fixed):
![phpbb-cdb-ext-desc-fix](https://github.com/phpbb/customisation-db/assets/8491069/c71e65f9-2ce9-48e0-90be-e409a5e19c7d)

A simple fix to prevent images expanding passed their maximum width for the container.