### PR TITLE
Fix bug where emojis in contrib title cause SQL error

### DIFF
--- a/config/controllers.yml
+++ b/config/controllers.yml
@@ -218,6 +218,8 @@ services:
             - '@phpbb.titania.attachment.uploader'
             - '@phpbb.titania.subscriptions'
             - '@phpbb.titania.message'
+            - '@text_formatter.parser'
+            - '@text_formatter.utils'
 
     phpbb.titania.controller.contrib.revision.edit:
         class: phpbb\titania\controller\contribution\revision_edit

--- a/config/controllers.yml
+++ b/config/controllers.yml
@@ -196,6 +196,7 @@ services:
             - '@phpbb.titania.attachment.uploader'
             - '@phpbb.titania.attachment.uploader'
             - '@phpbb.titania.subscriptions'
+            - '@text_formatter.parser'
 
     phpbb.titania.controller.contrib.revision:
         class: phpbb\titania\controller\contribution\revision

--- a/config/controllers.yml
+++ b/config/controllers.yml
@@ -197,6 +197,7 @@ services:
             - '@phpbb.titania.attachment.uploader'
             - '@phpbb.titania.subscriptions'
             - '@text_formatter.parser'
+            - '@text_formatter.utils'
 
     phpbb.titania.controller.contrib.revision:
         class: phpbb\titania\controller\contribution\revision

--- a/controller/contribution/manage.php
+++ b/controller/contribution/manage.php
@@ -40,6 +40,9 @@ class manage extends base
 	/** @var \phpbb\textformatter\s9e\parser */
 	protected $parser;
 
+	/** @var \phpbb\textformatter\s9e\utils */
+	protected $utils;
+
 	/** @var bool */
 	protected $is_moderator;
 
@@ -72,8 +75,9 @@ class manage extends base
 	 * @param \phpbb\titania\attachment\uploader $colorizeit_sample
 	 * @param \phpbb\titania\subscriptions $subscriptions
 	 * @param \phpbb\textformatter\s9e\parser $parser
+	 * @param \phpbb\textformatter\s9e\utils $utils
 	 */
-	public function __construct(\phpbb\auth\auth $auth, \phpbb\config\config $config, \phpbb\db\driver\driver_interface $db, \phpbb\template\template $template, \phpbb\user $user, \phpbb\titania\controller\helper $helper, type_collection $types, \phpbb\request\request $request, \phpbb\titania\cache\service $cache, \phpbb\titania\config\config $ext_config, \phpbb\titania\display $display, \phpbb\titania\access $access, \phpbb\titania\message\message $message, \phpbb\titania\attachment\uploader $screenshots, \phpbb\titania\attachment\uploader $colorizeit_sample, \phpbb\titania\subscriptions $subscriptions, \phpbb\textformatter\s9e\parser $parser)
+	public function __construct(\phpbb\auth\auth $auth, \phpbb\config\config $config, \phpbb\db\driver\driver_interface $db, \phpbb\template\template $template, \phpbb\user $user, \phpbb\titania\controller\helper $helper, type_collection $types, \phpbb\request\request $request, \phpbb\titania\cache\service $cache, \phpbb\titania\config\config $ext_config, \phpbb\titania\display $display, \phpbb\titania\access $access, \phpbb\titania\message\message $message, \phpbb\titania\attachment\uploader $screenshots, \phpbb\titania\attachment\uploader $colorizeit_sample, \phpbb\titania\subscriptions $subscriptions, \phpbb\textformatter\s9e\parser $parser, \phpbb\textformatter\s9e\utils $utils)
 	{
 		parent::__construct($auth, $config, $db, $template, $user, $helper, $types, $request, $cache, $ext_config, $display, $access);
 
@@ -82,6 +86,7 @@ class manage extends base
 		$this->colorizeit_sample = $colorizeit_sample;
 		$this->subscriptions = $subscriptions;
 		$this->parser = $parser;
+		$this->utils = $utils;
 	}
 
 	/**
@@ -716,6 +721,10 @@ class manage extends base
 				$this->contrib->type->id
 			);
 		}
+
+		// Unparse the contrib name
+		$this->contrib->contrib_name = $this->utils->unparse($this->contrib->contrib_name);
+
 		$this->message->display();
 		$this->contrib->assign_details();
 		$this->display->assign_global_vars();

--- a/controller/contribution/manage.php
+++ b/controller/contribution/manage.php
@@ -37,6 +37,9 @@ class manage extends base
 	/** @var \phpbb\titania\subscriptions */
 	protected $subscriptions;
 
+	/** @var \phpbb\textformatter\s9e\parser */
+	protected $parser;
+
 	/** @var bool */
 	protected $is_moderator;
 
@@ -68,8 +71,9 @@ class manage extends base
 	 * @param \phpbb\titania\attachment\uploader $screenshots
 	 * @param \phpbb\titania\attachment\uploader $colorizeit_sample
 	 * @param \phpbb\titania\subscriptions $subscriptions
+	 * @param \phpbb\textformatter\s9e\parser $parser
 	 */
-	public function __construct(\phpbb\auth\auth $auth, \phpbb\config\config $config, \phpbb\db\driver\driver_interface $db, \phpbb\template\template $template, \phpbb\user $user, \phpbb\titania\controller\helper $helper, type_collection $types, \phpbb\request\request $request, \phpbb\titania\cache\service $cache, \phpbb\titania\config\config $ext_config, \phpbb\titania\display $display, \phpbb\titania\access $access, \phpbb\titania\message\message $message, \phpbb\titania\attachment\uploader $screenshots, \phpbb\titania\attachment\uploader $colorizeit_sample, \phpbb\titania\subscriptions $subscriptions)
+	public function __construct(\phpbb\auth\auth $auth, \phpbb\config\config $config, \phpbb\db\driver\driver_interface $db, \phpbb\template\template $template, \phpbb\user $user, \phpbb\titania\controller\helper $helper, type_collection $types, \phpbb\request\request $request, \phpbb\titania\cache\service $cache, \phpbb\titania\config\config $ext_config, \phpbb\titania\display $display, \phpbb\titania\access $access, \phpbb\titania\message\message $message, \phpbb\titania\attachment\uploader $screenshots, \phpbb\titania\attachment\uploader $colorizeit_sample, \phpbb\titania\subscriptions $subscriptions, \phpbb\textformatter\s9e\parser $parser)
 	{
 		parent::__construct($auth, $config, $db, $template, $user, $helper, $types, $request, $cache, $ext_config, $display, $access);
 
@@ -77,6 +81,7 @@ class manage extends base
 		$this->screenshots = $screenshots;
 		$this->colorizeit_sample = $colorizeit_sample;
 		$this->subscriptions = $subscriptions;
+		$this->parser = $parser;
 	}
 
 	/**
@@ -489,6 +494,9 @@ class manage extends base
 
 		// Set custom field values.
 		$this->contrib->set_custom_fields($this->settings['custom']);
+
+		// Parse the contrib name so emojis can be used
+		$this->contrib->contrib_name = $this->parser->parse($this->contrib->contrib_name);
 
 		// Create relations
 		$this->contrib->put_contrib_in_categories(

--- a/controller/contribution/revision.php
+++ b/controller/contribution/revision.php
@@ -53,6 +53,12 @@ class revision extends base
 	/** @var bool */
 	private $skip_epv = false;
 
+	/** @var \phpbb\textformatter\s9e\parser */
+	protected $parser;
+
+	/** @var \phpbb\textformatter\s9e\utils */
+	protected $utils;
+
 	/**
 	 * Constructor
 	 *
@@ -71,14 +77,19 @@ class revision extends base
 	 * @param \phpbb\titania\attachment\uploader $uploader
 	 * @param \phpbb\titania\subscriptions $subscriptions
 	 * @param \phpbb\titania\message\message $message
+	 * @param \phpbb\textformatter\s9e\parser $parser
+	 * @param \phpbb\textformatter\s9e\utils $utils
 	 */
-	public function __construct(\phpbb\auth\auth $auth, \phpbb\config\config $config, \phpbb\db\driver\driver_interface $db, \phpbb\template\template $template, \phpbb\user $user, \phpbb\titania\controller\helper $helper, type_collection $types, \phpbb\request\request $request, \phpbb\titania\cache\service $cache, \phpbb\titania\config\config $ext_config, \phpbb\titania\display $display, \phpbb\titania\access $access, \phpbb\titania\attachment\uploader $uploader, \phpbb\titania\subscriptions $subscriptions, \phpbb\titania\message\message $message)
+	public function __construct(\phpbb\auth\auth $auth, \phpbb\config\config $config, \phpbb\db\driver\driver_interface $db, \phpbb\template\template $template, \phpbb\user $user, \phpbb\titania\controller\helper $helper, type_collection $types, \phpbb\request\request $request, \phpbb\titania\cache\service $cache, \phpbb\titania\config\config $ext_config, \phpbb\titania\display $display, \phpbb\titania\access $access, \phpbb\titania\attachment\uploader $uploader, \phpbb\titania\subscriptions $subscriptions, \phpbb\titania\message\message $message, \phpbb\textformatter\s9e\parser $parser, \phpbb\textformatter\s9e\utils $utils)
 	{
 		parent::__construct($auth, $config, $db, $template, $user, $helper, $types, $request, $cache, $ext_config, $display, $access);
 
 		$this->uploader = $uploader;
 		$this->subscriptions = $subscriptions;
 		$this->message = $message;
+
+		$this->parser = $parser;
+		$this->utils = $utils;
 
 		// Increase timeout when dealing with revisions
 		@set_time_limit(90);
@@ -216,6 +227,9 @@ class revision extends base
 
 		// Load the revisions for this contribution
 		$this->contrib->get_revisions();
+
+		// Unparse the contrib name
+		$this->contrib->contrib_name = $this->utils->unparse($this->contrib->contrib_name);
 
 		if (sizeof($this->contrib->revisions))
 		{


### PR DESCRIPTION
Interesting bug that a few people have noticed @LukeWCS @Crizz0 @vinny @danieltj27 - in Titania, if you're on Windows or Android, and use an emoji like 🆕 in the new contrib name it would spit out an SQL error like `Incorrect string value: '\xF0\x9F\x86\x95\x0AS...' ` when trying to submit. It's hard to reproduce because it seems to be fine on Mac.

My findings were that due to some code deep in Titania, unlike the other fields the actual contrib message/description seemed to be immune from this because it was being parsed to XML with the s9e text formatting library.

I've followed that lead to import s9e and parse/unparse the contrib names.

- [x] Fix contrib name using emojis on edit
- [ ] Check  emojis in original submission (create)
  - See /controller/author.php:421 
- [ ] Might need to parse/unparse other fields too (see #389)
- [ ] Unparse title on add revision page


