### PR TITLE
Fix Titania's failing Tool commands

### DIFF
--- a/console/command/composer/rebuild_repo.php
+++ b/console/command/composer/rebuild_repo.php
@@ -15,6 +15,7 @@ namespace phpbb\titania\console\command\composer;
 
 use phpbb\titania\manage\tool\composer\rebuild_repo as rebuild_tool;
 use phpbb\user;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -74,8 +75,8 @@ class rebuild_repo extends \phpbb\console\command\command
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
-		$progress = $this->getHelper('progress');
-		$progress->start($output, $this->tool->get_total());
+		$progress = new ProgressBar($output, $this->tool->get_total());
+		$progress->start();
 
 		$result = $this->tool
 			->set_start(0)

--- a/manage/tool/composer/rebuild_repo.php
+++ b/manage/tool/composer/rebuild_repo.php
@@ -268,7 +268,7 @@ class rebuild_repo extends base
 			$this->dump_include($last_type, $group, $packages);
 		}
 
-		$next_batch = $this->start + $this->limit;
+		$next_batch = $this->limit ? $this->start + $this->limit : $this->get_total();
 
 		if ($next_batch >= $this->get_total())
 		{

--- a/manage/tool/composer/rebuild_repo.php
+++ b/manage/tool/composer/rebuild_repo.php
@@ -22,7 +22,7 @@ use phpbb\titania\controller\helper;
 use phpbb\titania\entity\package;
 use phpbb\titania\ext;
 use phpbb\titania\manage\tool\base;
-use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Finder\SplFileInfo;
 
 class rebuild_repo extends base
@@ -175,7 +175,7 @@ class rebuild_repo extends base
 	 * 	from the revision zip files
 	 * @param bool|false $force		Force tool to run if a build is already
 	 * 	in progress
-	 * @param ProgressHelper|null $progress
+	 * @param ProgressBar|null $progress
 	 * @return array
 	 */
 	public function run($from_file = false, $force = false, $progress = null)

--- a/manage/tool/contribution/resync_count.php
+++ b/manage/tool/contribution/resync_count.php
@@ -208,7 +208,7 @@ class resync_count extends base
 			);
 			$sql = $this->db->sql_build_query('SELECT', $sql_ary);
 			$result = $this->db->sql_query($sql);
-			$this->total = (int) $this->db->sql_fetchfield('cnt', $result);
+			$this->total = (int) $this->db->sql_fetchfield('cnt');
 			$this->db->sql_freeresult($result);
 		}
 

--- a/manage/tool/contribution/resync_count.php
+++ b/manage/tool/contribution/resync_count.php
@@ -19,7 +19,7 @@ use phpbb\titania\contribution\type\collection as type_collection;
 use phpbb\titania\ext;
 use phpbb\titania\manage\tool\base;
 use phpbb\user;
-use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 class resync_count extends base
 {
@@ -74,7 +74,7 @@ class resync_count extends base
 	 * Run the tool
 	 *
 	 * @param int $prev_contrib				Previous contrib that was resynced
-	 * @param ProgressHelper|null $progress
+	 * @param ProgressBar|null $progress
 	 * @return array
 	 */
 	public function run($prev_contrib = 0, $progress = null)

--- a/manage/tool/contribution/update_release_topics.php
+++ b/manage/tool/contribution/update_release_topics.php
@@ -20,7 +20,7 @@ use phpbb\titania\ext;
 use phpbb\titania\manage\tool\base;
 use phpbb\titania\versions;
 use phpbb\user;
-use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 class update_release_topics extends base
 {
@@ -194,7 +194,7 @@ class update_release_topics extends base
 	/**
 	 * Run the tool
 	 *
-	 * @param ProgressHelper|null $progress
+	 * @param ProgressBar|null $progress
 	 * @return array
 	 */
 	public function run($progress = null)

--- a/manage/tool/contribution/update_release_topics.php
+++ b/manage/tool/contribution/update_release_topics.php
@@ -93,7 +93,7 @@ class update_release_topics extends base
 						)) . '
 						AND ' . $this->db->sql_in_set('contrib_type', $types);
 				$result = $this->db->sql_query($sql);
-				$this->total = (int) $this->db->sql_fetchfield('cnt', $result);
+				$this->total = (int) $this->db->sql_fetchfield('cnt');
 				$this->db->sql_freeresult($result);
 			}
 			else

--- a/manage/tool/search/reindex.php
+++ b/manage/tool/search/reindex.php
@@ -19,7 +19,7 @@ use phpbb\titania\manage\tool\base;
 use phpbb\titania\search\manager as search_manager;
 use phpbb\titania\sync;
 use phpbb\user;
-use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 class reindex extends base
 {
@@ -155,7 +155,7 @@ class reindex extends base
 	/**
 	 * Run tool
 	 *
-	 * @param ProgressHelper|null $progress
+	 * @param ProgressBar|null $progress
 	 * @return array
 	 */
 	public function run($progress = null)

--- a/manage/tool/search/reindex.php
+++ b/manage/tool/search/reindex.php
@@ -114,7 +114,7 @@ class reindex extends base
 		$sql = 'SELECT COUNT(contrib_id) AS cnt
 			FROM ' . $this->contribs_table;
 		$result = $this->db->sql_query($sql);
-		$total = (int) $this->db->sql_fetchfield('cnt', $result);
+		$total = (int) $this->db->sql_fetchfield('cnt');
 		$this->db->sql_freeresult($result);
 
 		return $total;
@@ -130,7 +130,7 @@ class reindex extends base
 		$sql = 'SELECT COUNT(faq_id) AS cnt
 			FROM ' . $this->contrib_faq_table;
 		$result = $this->db->sql_query($sql);
-		$total = (int) $this->db->sql_fetchfield('cnt', $result);
+		$total = (int) $this->db->sql_fetchfield('cnt');
 		$this->db->sql_freeresult($result);
 
 		return $total;
@@ -146,7 +146,7 @@ class reindex extends base
 		$sql = 'SELECT COUNT(post_id) AS cnt
 			FROM ' . $this->posts_table;
 		$result = $this->db->sql_query($sql);
-		$total = (int) $this->db->sql_fetchfield('cnt', $result);
+		$total = (int) $this->db->sql_fetchfield('cnt');
 		$this->db->sql_freeresult($result);
 
 		return $total;

--- a/manage/tool/topic/rebuild_urls.php
+++ b/manage/tool/topic/rebuild_urls.php
@@ -20,7 +20,7 @@ use phpbb\titania\contribution\type\collection as type_collection;
 use phpbb\titania\ext;
 use phpbb\titania\manage\tool\base;
 use phpbb\user;
-use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 class rebuild_urls extends base
 {
@@ -75,7 +75,7 @@ class rebuild_urls extends base
 	/**
 	 * Run tool.
 	 *
-	 * @param ProgressHelper|null $progress
+	 * @param ProgressBar|null $progress
 	 * @return array
 	 */
 	public function run($progress = null)

--- a/manage/tool/topic/resync_dots.php
+++ b/manage/tool/topic/resync_dots.php
@@ -18,7 +18,7 @@ use phpbb\db\sql_insert_buffer;
 use phpbb\titania\config\config as ext_config;
 use phpbb\titania\manage\tool\base;
 use phpbb\user;
-use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 class resync_dots extends base
 {
@@ -96,7 +96,7 @@ class resync_dots extends base
 	/**
 	 * Run the tool
 	 *
-	 * @param ProgressHelper|null $progress
+	 * @param ProgressBar|null $progress
 	 * @return array
 	 */
 	public function run($progress = null)

--- a/manage/tool/topic/resync_dots.php
+++ b/manage/tool/topic/resync_dots.php
@@ -68,7 +68,7 @@ class resync_dots extends base
 				WHERE post_approved = 1
 					AND post_deleted = 0';
 				$result = $this->db->sql_query($sql);
-			$this->total = (int) $this->db->sql_fetchfield('cnt', $result);
+			$this->total = (int) $this->db->sql_fetchfield('cnt');
 			$this->db->sql_freeresult($result);
 		}
 

--- a/sync.php
+++ b/sync.php
@@ -252,7 +252,7 @@ class sync
 						WHERE contrib_id = ' . $row['contrib_id'] . '
 							AND revision_status = ' . ext::TITANIA_REVISION_APPROVED;
 					$result1 = $this->db->sql_query($sql);
-					$cnt = $this->db->sql_fetchfield('cnt', $result1);
+					$cnt = $this->db->sql_fetchfield('cnt', false, $result1);
 					$this->db->sql_freeresult($result1);
 
 					if (($cnt > 0 && $row['contrib_status'] == ext::TITANIA_CONTRIB_NEW) || ($cnt == 0 && $row['contrib_status'] == ext::TITANIA_CONTRIB_APPROVED))
@@ -631,7 +631,7 @@ class sync
 				AND post_deleted = 0
 				AND post_approved = 1';
 		$result = $this->db->sql_query($sql);
-		$teams = $this->db->sql_fetchfield('cnt', $result);
+		$teams = $this->db->sql_fetchfield('cnt', false, $result);
 		$this->db->sql_freeresult($result);
 
 		$sql = 'SELECT COUNT(post_id) AS cnt
@@ -641,7 +641,7 @@ class sync
 				AND post_deleted = 0
 				AND post_approved = 1';
 		$result = $this->db->sql_query($sql);
-		$authors = $this->db->sql_fetchfield('cnt', $result);
+		$authors = $this->db->sql_fetchfield('cnt', false, $result);
 		$this->db->sql_freeresult($result);
 
 		$sql = 'SELECT COUNT(post_id) AS cnt
@@ -651,7 +651,7 @@ class sync
 				AND post_deleted = 0
 				AND post_approved = 1';
 		$result = $this->db->sql_query($sql);
-		$public = $this->db->sql_fetchfield('cnt', $result);
+		$public = $this->db->sql_fetchfield('cnt', false, $result);
 		$this->db->sql_freeresult($result);
 
 		$sql = 'SELECT COUNT(post_id) AS cnt
@@ -659,7 +659,7 @@ class sync
 			WHERE topic_id = ' . (int) $topic_id . '
 				AND post_deleted <> 0';
 		$result = $this->db->sql_query($sql);
-		$deleted = $this->db->sql_fetchfield('cnt', $result);
+		$deleted = $this->db->sql_fetchfield('cnt', false, $result);
 		$this->db->sql_freeresult($result);
 
 		$sql = 'SELECT COUNT(post_id) AS cnt
@@ -668,7 +668,7 @@ class sync
 				AND post_deleted = 0
 				AND post_approved = 0';
 		$result = $this->db->sql_query($sql);
-		$unapproved = $this->db->sql_fetchfield('cnt', $result);
+		$unapproved = $this->db->sql_fetchfield('cnt', false, $result);
 		$this->db->sql_freeresult($result);
 
 		return count::to_db(array(


### PR DESCRIPTION
Tool commands were using a removed Symfony 2 component, needs to be updated for Symfony 3. Also some mysql/php failures fixed too.