### PR TITLE
Composer repository builder should also make a phpBB4 only packages.json

### DIFF
--- a/composer/repository.php
+++ b/composer/repository.php
@@ -15,6 +15,7 @@ namespace phpbb\titania\composer;
 
 use phpbb\config\config;
 use phpbb\exception\runtime_exception;
+use phpbb\titania\ext;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
@@ -170,15 +171,17 @@ class repository
 	/**
 	 * Get include files.
 	 *
+	 * @param string $prefix Optional prefix to filter files
 	 * @return Finder
 	 */
-	protected function get_include_files()
+	protected function get_include_files($prefix = '')
 	{
 		$finder = new Finder;
+		$pattern = $prefix ? '/^packages\-' . preg_quote($prefix, '/') . '[a-z]+\-\d+\.json$/' : '/^packages\-[a-z]+\-\d+\.json$/';
 		$finder
 			->files()
 			->depth('== 0')
-			->name('/^packages\-[a-z]+\-\d+\.json$/')
+			->name($pattern)
 			->in($this->build_dir)
 		;
 
@@ -190,12 +193,23 @@ class repository
 	 */
 	protected function build_parents()
 	{
-		$includes = $this->get_include_files();
+		$this->build_parent_structure();
+		$this->build_parent_structure(ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH . '-');
+	}
+
+	/**
+	 * Build parent structure for given prefix
+	 *
+	 * @param string $prefix Optional prefix for files
+	 */
+	protected function build_parent_structure($prefix = '')
+	{
+		$includes = $this->get_include_files($prefix);
 		$parent = $types = array();
 
 		foreach ($includes as $file)
 		{
-			$type = $this->get_include_type($file->getFilename());
+			$type = $this->get_include_type($file->getFilename(), $prefix);
 
 			if ($type)
 			{
@@ -211,7 +225,7 @@ class repository
 
 		foreach ($types as $type => $includes)
 		{
-			$type_filename = 'packages-' . $type . '.json';
+			$type_filename = $prefix ? 'packages-' . $prefix . $type . '.json' : 'packages-' . $type . '.json';
 			$type_filepath = $this->build_dir . $type_filename;
 			$contents = json_encode(array('includes' => $includes));
 			$this->fs->dumpFile($type_filepath, $contents);
@@ -222,8 +236,9 @@ class repository
 		}
 		if (!empty($parent))
 		{
+			$main_filename = $prefix ? 'packages-' . rtrim($prefix, '-') . '.json' : 'packages.json';
 			$contents = json_encode(array('includes' => $parent));
-			$this->fs->dumpFile($this->build_dir . 'packages.json', $contents);
+			$this->fs->dumpFile($this->build_dir . $main_filename, $contents);
 		}
 	}
 
@@ -231,14 +246,16 @@ class repository
 	 * Get contrib type name from include file name.
 	 *
 	 * @param string $filename
+	 * @param string $prefix Optional prefix to match
 	 * @return bool|string Returns contrib type name or false if not a valid filename
 	 */
-	protected function get_include_type($filename)
+	protected function get_include_type($filename, $prefix = '')
 	{
 		$filename = utf8_basename($filename);
 		$match = array();
+		$pattern = $prefix ? '/^packages\-' . preg_quote($prefix, '/') . '([a-z]+)\-\d+\.json$/' : '/^packages\-([a-z]+)\-\d+\.json$/';
 
-		if (preg_match('/^packages\-([a-z]+)\-\d+\.json$/', $filename, $match))
+		if (preg_match($pattern, $filename, $match))
 		{
 			return $match[1];
 		}

--- a/composer/repository.php
+++ b/composer/repository.php
@@ -64,6 +64,13 @@ class repository
 		}
 		$this->fs->mkdir($this->build_dir);
 
+		// Create filtered repository subdirectories
+		$branches = ext::get_filtered_repository_branches();
+		foreach ($branches as $branch)
+		{
+			$this->fs->mkdir($this->build_dir . $branch);
+		}
+
 		return $this;
 	}
 
@@ -166,10 +173,6 @@ class repository
 			JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
 		);
 		$target_dir = $this->build_dir . $subdir;
-		if ($subdir && !$this->fs->exists($target_dir))
-		{
-			$this->fs->mkdir($target_dir);
-		}
 		$file = $target_dir . $name;
 		$this->fs->dumpFile($file, $packages);
 	}
@@ -215,11 +218,6 @@ class repository
 		$includes = $this->get_include_files();
 		$parent = $types = array();
 		$target_dir = $this->build_dir . $subdir;
-		
-		if ($subdir && !$this->fs->exists($target_dir))
-		{
-			$this->fs->mkdir($target_dir);
-		}
 
 		foreach ($includes as $file)
 		{

--- a/composer/repository.php
+++ b/composer/repository.php
@@ -194,7 +194,11 @@ class repository
 	protected function build_parents()
 	{
 		$this->build_parent_structure();
-		$this->build_parent_structure(ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH . '-');
+		$branches = ext::get_filtered_repository_branches();
+		foreach ($branches as $branch)
+		{
+			$this->build_parent_structure($branch . '-');
+		}
 	}
 
 	/**

--- a/composer/repository.php
+++ b/composer/repository.php
@@ -153,8 +153,9 @@ class repository
 	 *
 	 * @param string $name		File name
 	 * @param array $packages	Packages to be dumped
+	 * @param string $subdir	Optional subdirectory
 	 */
-	public function dump_include($name, array $packages)
+	public function dump_include($name, array $packages, $subdir = '')
 	{
 		foreach ($packages as $package_name => $versions)
 		{
@@ -164,24 +165,27 @@ class repository
 			array('packages' => $packages),
 			JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
 		);
-		$file = $this->build_dir . $name;
+		$target_dir = $this->build_dir . $subdir;
+		if ($subdir && !$this->fs->exists($target_dir))
+		{
+			$this->fs->mkdir($target_dir);
+		}
+		$file = $target_dir . $name;
 		$this->fs->dumpFile($file, $packages);
 	}
 
 	/**
 	 * Get include files.
 	 *
-	 * @param string $prefix Optional prefix to filter files
 	 * @return Finder
 	 */
-	protected function get_include_files($prefix = '')
+	protected function get_include_files()
 	{
 		$finder = new Finder;
-		$pattern = $prefix ? '/^packages\-' . preg_quote($prefix, '/') . '[a-z]+\-\d+\.json$/' : '/^packages\-[a-z]+\-\d+\.json$/';
 		$finder
 			->files()
 			->depth('== 0')
-			->name($pattern)
+			->name('/^packages\-[a-z]+\-\d+\.json$/')
 			->in($this->build_dir)
 		;
 
@@ -197,23 +201,29 @@ class repository
 		$branches = ext::get_filtered_repository_branches();
 		foreach ($branches as $branch)
 		{
-			$this->build_parent_structure($branch . '-');
+			$this->build_parent_structure($branch . '/');
 		}
 	}
 
 	/**
-	 * Build parent structure for given prefix
+	 * Build parent structure for given subdirectory
 	 *
-	 * @param string $prefix Optional prefix for files
+	 * @param string $subdir Optional subdirectory
 	 */
-	protected function build_parent_structure($prefix = '')
+	protected function build_parent_structure($subdir = '')
 	{
-		$includes = $this->get_include_files($prefix);
+		$includes = $this->get_include_files();
 		$parent = $types = array();
+		$target_dir = $this->build_dir . $subdir;
+		
+		if ($subdir && !$this->fs->exists($target_dir))
+		{
+			$this->fs->mkdir($target_dir);
+		}
 
 		foreach ($includes as $file)
 		{
-			$type = $this->get_include_type($file->getFilename(), $prefix);
+			$type = $this->get_include_type($file->getFilename());
 
 			if ($type)
 			{
@@ -229,8 +239,8 @@ class repository
 
 		foreach ($types as $type => $includes)
 		{
-			$type_filename = $prefix ? 'packages-' . $prefix . $type . '.json' : 'packages-' . $type . '.json';
-			$type_filepath = $this->build_dir . $type_filename;
+			$type_filename = 'packages-' . $type . '.json';
+			$type_filepath = $target_dir . $type_filename;
 			$contents = json_encode(array('includes' => $includes));
 			$this->fs->dumpFile($type_filepath, $contents);
 
@@ -240,9 +250,8 @@ class repository
 		}
 		if (!empty($parent))
 		{
-			$main_filename = $prefix ? 'packages-' . rtrim($prefix, '-') . '.json' : 'packages.json';
 			$contents = json_encode(array('includes' => $parent));
-			$this->fs->dumpFile($this->build_dir . $main_filename, $contents);
+			$this->fs->dumpFile($target_dir . 'packages.json', $contents);
 		}
 	}
 
@@ -250,16 +259,14 @@ class repository
 	 * Get contrib type name from include file name.
 	 *
 	 * @param string $filename
-	 * @param string $prefix Optional prefix to match
 	 * @return bool|string Returns contrib type name or false if not a valid filename
 	 */
-	protected function get_include_type($filename, $prefix = '')
+	protected function get_include_type($filename)
 	{
 		$filename = utf8_basename($filename);
 		$match = array();
-		$pattern = $prefix ? '/^packages\-' . preg_quote($prefix, '/') . '([a-z]+)\-\d+\.json$/' : '/^packages\-([a-z]+)\-\d+\.json$/';
 
-		if (preg_match($pattern, $filename, $match))
+		if (preg_match('/^packages\-([a-z]+)\-\d+\.json$/', $filename, $match))
 		{
 			return $match[1];
 		}

--- a/config/routes/general.yml
+++ b/config/routes/general.yml
@@ -64,13 +64,13 @@ phpbb.titania.contribution.id:
     requirements:
         id: \d+
 
-phpbb.titania.composer:
-    path: /composer/{filename}.json
-    defaults: { _controller: phpbb.titania.controller.composer:serve_file }
-
 phpbb.titania.composer.40:
   path: /composer/40/
   defaults: { _controller: phpbb.titania.controller.composer:serve_file, filename: packages-40 }
+
+phpbb.titania.composer:
+    path: /composer/{filename}.json
+    defaults: { _controller: phpbb.titania.controller.composer:serve_file }
 
 phpbb.titania.category:
     path: /{category1}/{category2}/{category3}/{category4}

--- a/config/routes/general.yml
+++ b/config/routes/general.yml
@@ -64,9 +64,13 @@ phpbb.titania.contribution.id:
     requirements:
         id: \d+
 
+phpbb.titania.composer.40.files:
+    path: /composer/40/{filename}.json
+    defaults: { _controller: phpbb.titania.controller.composer:serve_file }
+
 phpbb.titania.composer.40:
-  path: /composer/40/
-  defaults: { _controller: phpbb.titania.controller.composer:serve_file, filename: packages-40 }
+    path: /composer/40/
+    defaults: { _controller: phpbb.titania.controller.composer:serve_file, filename: packages-40 }
 
 phpbb.titania.composer:
     path: /composer/{filename}.json

--- a/config/routes/general.yml
+++ b/config/routes/general.yml
@@ -66,11 +66,11 @@ phpbb.titania.contribution.id:
 
 phpbb.titania.composer.40.files:
     path: /composer/40/{filename}.json
-    defaults: { _controller: phpbb.titania.controller.composer:serve_file }
+    defaults: { _controller: phpbb.titania.controller.composer:serve_file, subdirectory: '40/' }
 
 phpbb.titania.composer.40:
     path: /composer/40/
-    defaults: { _controller: phpbb.titania.controller.composer:serve_file, filename: packages-40 }
+    defaults: { _controller: phpbb.titania.controller.composer:serve_file, filename: packages, subdirectory: '40/' }
 
 phpbb.titania.composer:
     path: /composer/{filename}.json

--- a/config/routes/general.yml
+++ b/config/routes/general.yml
@@ -68,6 +68,10 @@ phpbb.titania.composer:
     path: /composer/{filename}.json
     defaults: { _controller: phpbb.titania.controller.composer:serve_file }
 
+phpbb.titania.composer.40:
+  path: /composer/40/
+  defaults: { _controller: phpbb.titania.controller.composer:serve_file, filename: packages-40 }
+
 phpbb.titania.category:
     path: /{category1}/{category2}/{category3}/{category4}
     defaults: { _controller: phpbb.titania.controller.index:display_category, category2: '', category3: '', category4: '' }

--- a/controller/composer.php
+++ b/controller/composer.php
@@ -44,20 +44,21 @@ class composer
 	* Serve composer's files.
 	*
 	* @param string $filename	Filename to serve (without extension)
+	* @param string $subdirectory	Optional subdirectory
 	* @return \Symfony\Component\HttpFoundation\Response
 	*/
-	public function serve_file($filename)
+	public function serve_file($filename, $subdirectory = '')
 	{
-		if (strpos($filename, '..') !== false)
+		if (strpos($filename, '..') !== false || strpos($subdirectory, '..') !== false)
 		{
 			throw new http_exception(404, 'NO_PAGE_FOUND');
 		}
 
-		$filename = $this->titania_root_path . 'composer_packages/prod/' . $filename . '.json';
+		$filepath = $this->titania_root_path . 'composer_packages/prod/' . $subdirectory . $filename . '.json';
 
 		try
 		{
-			return new BinaryFileResponse($filename, 200);
+			return new BinaryFileResponse($filepath, 200);
 		}
 		catch (\Exception $e)
 		{

--- a/ext.php
+++ b/ext.php
@@ -95,5 +95,14 @@ class ext extends \phpbb\extension\base
 
 	// Misc
 	const TITANIA_CONFIG_PREFIX = 'titania_';
-	const TITANIA_REPOSITORY_MIN_PHPBB_BRANCH = 40;
+
+	/**
+	 * Get filtered repository branch versions
+	 *
+	 * @return array Array of branch numbers to create filtered repositories for
+	 */
+	public static function get_filtered_repository_branches(): array
+	{
+		return [40];
+	}
 }

--- a/ext.php
+++ b/ext.php
@@ -95,4 +95,5 @@ class ext extends \phpbb\extension\base
 
 	// Misc
 	const TITANIA_CONFIG_PREFIX = 'titania_';
+	const TITANIA_REPOSITORY_MIN_PHPBB_BRANCH = 40;
 }

--- a/manage/tool/composer/rebuild_repo.php
+++ b/manage/tool/composer/rebuild_repo.php
@@ -322,13 +322,13 @@ class rebuild_repo extends base
 	 * @param string $type		Contrib type name
 	 * @param int $group		Group id
 	 * @param array $packages	Packages
-	 * @param string $suffix	Optional suffix for filename
+	 * @param int $branch		Optional branch number for subdirectory
 	 */
-	protected function dump_include($type, $group, array $packages, $prefix = '')
+	protected function dump_include($type, $group, array $packages, $branch = null)
 	{
 		$type_name = $this->types->get($type)->name;
-		$filename = $prefix ? "packages-$prefix-$type_name-$group.json" : "packages-$type_name-$group.json";
-		$this->repo->dump_include($filename, $packages);
+		$subdir = $branch ? $branch . '/' : '';
+		$this->repo->dump_include("packages-$type_name-$group.json", $packages, $subdir);
 	}
 
 	/**

--- a/manage/tool/composer/rebuild_repo.php
+++ b/manage/tool/composer/rebuild_repo.php
@@ -23,7 +23,6 @@ use phpbb\titania\entity\package;
 use phpbb\titania\ext;
 use phpbb\titania\manage\tool\base;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Finder\SplFileInfo;
 
 class rebuild_repo extends base
 {
@@ -57,6 +56,9 @@ class rebuild_repo extends base
 	/** @var string */
 	protected $revisions_table;
 
+	/** @var string */
+	protected $revisions_phpbb_table;
+
 	/** @var int */
 	protected $total;
 
@@ -84,6 +86,7 @@ class rebuild_repo extends base
 		$this->attachments_table = $table_prefix . 'attachments';
 		$this->contribs_table = $table_prefix . 'contribs';
 		$this->revisions_table = $table_prefix . 'revisions';
+		$this->revisions_phpbb_table = $table_prefix . 'revisions_phpbb';
 	}
 
 	/**
@@ -105,10 +108,13 @@ class rebuild_repo extends base
 
 			$sql = 'SELECT COUNT(r.revision_id) AS cnt
 				FROM ' . $this->contribs_table . ' c, ' .
-				$this->revisions_table . ' r
+				$this->revisions_table . ' r, ' .
+				$this->revisions_phpbb_table . ' rp
 				WHERE c.contrib_id = r.contrib_id
+					AND r.revision_id = rp.revision_id
 					AND c.contrib_status = ' . ext::TITANIA_CONTRIB_APPROVED . '
 					AND r.revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
+					AND rp.phpbb_version_branch >= ' . ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH . '
 					AND ' . $this->db->sql_in_set('c.contrib_type', $types);
 			$this->db->sql_query($sql);
 			$this->total = (int) $this->db->sql_fetchfield('cnt');
@@ -142,12 +148,15 @@ class rebuild_repo extends base
 		$sql = 'SELECT c.contrib_id, c.contrib_name_clean, c.contrib_type, r.revision_id,
 				r.attachment_id, r.revision_composer_json' . $attach_fields . '
 			FROM ' . $this->contribs_table . ' c, ' .
-			$this->revisions_table . ' r ' .
+			$this->revisions_table . ' r, ' .
+			$this->revisions_phpbb_table . ' rp ' .
 			$attach_table . '
-			WHERE c.contrib_id = r.contrib_id ' .
+			WHERE c.contrib_id = r.contrib_id
+				AND r.revision_id = rp.revision_id ' .
 			$attach_where . '
 				AND c.contrib_status = ' . ext::TITANIA_CONTRIB_APPROVED . '
 				AND r.revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
+				AND rp.phpbb_version_branch >= ' . ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH . '
 				AND ' . $this->db->sql_in_set('c.contrib_type', $types) . '
 			ORDER BY c.contrib_id ASC, r.revision_id ASC';
 		$result = $this->db->sql_query_limit($sql, $this->limit, $this->start);

--- a/manage/tool/composer/rebuild_repo.php
+++ b/manage/tool/composer/rebuild_repo.php
@@ -197,7 +197,12 @@ class rebuild_repo extends base
 
 		$last_type = $last_contrib = '';
 		$packages = array();
-		$packages_phpbb4_only = array();
+		$filtered_packages = array();
+		$branches = ext::get_filtered_repository_branches();
+		foreach ($branches as $branch)
+		{
+			$filtered_packages[$branch] = array();
+		}
 
 		foreach ($batch as $contrib_id => $revisions)
 		{
@@ -253,14 +258,17 @@ class rebuild_repo extends base
 					$contrib_url
 				);
 
-				if ($revision['phpbb_version_branch'] >= ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH)
+				foreach ($filtered_packages as $branch => $packages_data)
 				{
-					$packages_phpbb4_only = $this->repo->set_release(
-						$packages_phpbb4_only,
-						$revision['revision_composer_json'],
-						$download_url,
-						$contrib_url
-					);
+					if ($revision['phpbb_version_branch'] >= $branch)
+					{
+						$filtered_packages[$branch] = $this->repo->set_release(
+							$filtered_packages[$branch],
+							$revision['revision_composer_json'],
+							$download_url,
+							$contrib_url
+						);
+					}
 				}
 
 				unset($batch[$contrib_id][$index]);
@@ -274,18 +282,24 @@ class rebuild_repo extends base
 			if (($group_count % 50) === 0)
 			{
 				$this->dump_include($last_type, $group, $packages);
-				$this->dump_include($last_type, $group, $packages_phpbb4_only, ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH);
+				foreach ($filtered_packages as $branch => $packages_data)
+				{
+					$this->dump_include($last_type, $group, $packages_data, $branch);
+					$filtered_packages[$branch] = array();
+				}
 				$group_count = 0;
 				$group++;
 				$packages = array();
-				$packages_phpbb4_only = array();
 			}
 			$group_count++;
 		}
 		if (!empty($packages))
 		{
 			$this->dump_include($last_type, $group, $packages);
-			$this->dump_include($last_type, $group, $packages_phpbb4_only, ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH);
+			foreach ($filtered_packages as $branch => $packages_data)
+			{
+				$this->dump_include($last_type, $group, $packages_data, $branch);
+			}
 		}
 
 		$next_batch = $this->limit ? $this->start + $this->limit : $this->get_total();

--- a/manage/tool/composer/rebuild_repo.php
+++ b/manage/tool/composer/rebuild_repo.php
@@ -108,13 +108,10 @@ class rebuild_repo extends base
 
 			$sql = 'SELECT COUNT(r.revision_id) AS cnt
 				FROM ' . $this->contribs_table . ' c, ' .
-				$this->revisions_table . ' r, ' .
-				$this->revisions_phpbb_table . ' rp
+				$this->revisions_table . ' r
 				WHERE c.contrib_id = r.contrib_id
-					AND r.revision_id = rp.revision_id
 					AND c.contrib_status = ' . ext::TITANIA_CONTRIB_APPROVED . '
 					AND r.revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
-					AND rp.phpbb_version_branch >= ' . ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH . '
 					AND ' . $this->db->sql_in_set('c.contrib_type', $types);
 			$this->db->sql_query($sql);
 			$this->total = (int) $this->db->sql_fetchfield('cnt');
@@ -146,7 +143,7 @@ class rebuild_repo extends base
 		}
 
 		$sql = 'SELECT c.contrib_id, c.contrib_name_clean, c.contrib_type, r.revision_id,
-				r.attachment_id, r.revision_composer_json' . $attach_fields . '
+				r.attachment_id, r.revision_composer_json, rp.phpbb_version_branch' . $attach_fields . '
 			FROM ' . $this->contribs_table . ' c, ' .
 			$this->revisions_table . ' r, ' .
 			$this->revisions_phpbb_table . ' rp ' .
@@ -156,7 +153,6 @@ class rebuild_repo extends base
 			$attach_where . '
 				AND c.contrib_status = ' . ext::TITANIA_CONTRIB_APPROVED . '
 				AND r.revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
-				AND rp.phpbb_version_branch >= ' . ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH . '
 				AND ' . $this->db->sql_in_set('c.contrib_type', $types) . '
 			ORDER BY c.contrib_id ASC, r.revision_id ASC';
 		$result = $this->db->sql_query_limit($sql, $this->limit, $this->start);
@@ -201,6 +197,7 @@ class rebuild_repo extends base
 
 		$last_type = $last_contrib = '';
 		$packages = array();
+		$packages_phpbb4_only = array();
 
 		foreach ($batch as $contrib_id => $revisions)
 		{
@@ -255,6 +252,17 @@ class rebuild_repo extends base
 					$download_url,
 					$contrib_url
 				);
+
+				if ($revision['phpbb_version_branch'] >= ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH)
+				{
+					$packages_phpbb4_only = $this->repo->set_release(
+						$packages_phpbb4_only,
+						$revision['revision_composer_json'],
+						$download_url,
+						$contrib_url
+					);
+				}
+
 				unset($batch[$contrib_id][$index]);
 			}
 
@@ -266,15 +274,18 @@ class rebuild_repo extends base
 			if (($group_count % 50) === 0)
 			{
 				$this->dump_include($last_type, $group, $packages);
+				$this->dump_include($last_type, $group, $packages_phpbb4_only, ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH);
 				$group_count = 0;
 				$group++;
 				$packages = array();
+				$packages_phpbb4_only = array();
 			}
 			$group_count++;
 		}
 		if (!empty($packages))
 		{
 			$this->dump_include($last_type, $group, $packages);
+			$this->dump_include($last_type, $group, $packages_phpbb4_only, ext::TITANIA_REPOSITORY_MIN_PHPBB_BRANCH);
 		}
 
 		$next_batch = $this->limit ? $this->start + $this->limit : $this->get_total();
@@ -297,11 +308,13 @@ class rebuild_repo extends base
 	 * @param string $type		Contrib type name
 	 * @param int $group		Group id
 	 * @param array $packages	Packages
+	 * @param string $suffix	Optional suffix for filename
 	 */
-	protected function dump_include($type, $group, array $packages)
+	protected function dump_include($type, $group, array $packages, $prefix = '')
 	{
 		$type_name = $this->types->get($type)->name;
-		$this->repo->dump_include("packages-$type_name-$group.json", $packages);
+		$filename = $prefix ? "packages-$prefix-$type_name-$group.json" : "packages-$type_name-$group.json";
+		$this->repo->dump_include($filename, $packages);
 	}
 
 	/**


### PR DESCRIPTION
@DavidIQ and @marc1706 This PR would be in addition to https://github.com/phpbb/phpbb/pull/6873

This PR updates the composer repo build for phpBB4’s extension catalog so that only extensions marked as supporting the phpBB 4 branch get included. Basically, it cuts down the risk of presenting extensions that aren’t submitted & validated for phpBB4 and could break boards.