### PR TITLE
Fix composer installers from overwriting author intent

### DIFF
--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -280,7 +280,7 @@ class type extends base
 
 		$ext_name = $data['name'];
 		$data['type'] = 'phpbb-extension';
-		$data = $this->update_phpbb_requirement($data);
+		$data = $this->update_phpbb_requirement($data, $revision);
 		$data = $this->set_version_check($data, $contrib);
 
 		$data = json_encode(
@@ -352,9 +352,10 @@ class type extends base
 	 * Updates phpBB requirements in composer.json
 	 *
 	 * @param array $data composer.json data
+	 * @param \titania_revision $revision
 	 * @return array Returns $data array with phpBB requirement updated
 	 */
-	protected function update_phpbb_requirement(array $data)
+	protected function update_phpbb_requirement(array $data, \titania_revision $revision)
 	{
 		if (!isset($data['require']['phpbb/phpbb']))
 		{
@@ -374,7 +375,7 @@ class type extends base
 		if (!isset($data['require']['composer/installers']))
 		{
 			$installers_version = '~1.0';
-			if (isset($data['require']['phpbb/phpbb']) && $this->requires_phpbb_4_or_higher($data['require']['phpbb/phpbb']))
+			if ($this->is_phpbb_4_branch($revision) || (isset($data['require']['phpbb/phpbb']) && $this->requires_phpbb_4($data['require']['phpbb/phpbb'])))
 			{
 				$installers_version = '^1.0 || ^2.0';
 			}
@@ -401,7 +402,7 @@ class type extends base
 	 * @param string $constraint Version constraint
 	 * @return bool True if constraint requires phpBB 4.0.0+
 	 */
-	protected function requires_phpbb_4_or_higher($constraint)
+	protected function requires_phpbb_4($constraint)
 	{
 		try
 		{
@@ -416,6 +417,17 @@ class type extends base
 		{
 			return false;
 		}
+	}
+
+	/**
+	 * Check if revision is submitted to phpBB 4.0+ branch
+	 *
+	 * @param \titania_revision $revision
+	 * @return bool True if submitted to phpBB 4.0+ branch
+	 */
+	protected function is_phpbb_4_branch(\titania_revision $revision)
+	{
+		return max(array_column($revision->phpbb_versions, 'phpbb_version_branch')) >= 40;
 	}
 
 	/**

--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -396,19 +396,21 @@ class type extends base
 	}
 
 	/**
-	 * Check if phpBB requirement allows 4.0.0 or higher
+	 * Check if phpBB requires 4.0.0 or higher
 	 *
 	 * @param string $constraint Version constraint
-	 * @return bool True if constraint allows phpBB 4.0.0+
+	 * @return bool True if constraint requires phpBB 4.0.0+
 	 */
 	protected function requires_phpbb_4_or_higher($constraint)
 	{
 		try
 		{
 			$parser = new \Composer\Semver\VersionParser();
-			$constraintObj = $parser->parseConstraints($constraint);
-			// Check if the constraint excludes versions below 4.0.0 by testing if 3.9.9 does NOT satisfy the constraint
-			return !$constraintObj->matches(new \Composer\Semver\Constraint\Constraint('==', '3.9.9.0'));
+			$constraint_obj = $parser->parseConstraints($constraint);
+			$phpbb4_constraint = $parser->parseConstraints('>=4.0.0');
+			$phpbb3_constraint = $parser->parseConstraints('<4.0.0');
+			// Check if constraint allows 4.0.0+ and excludes all versions below 4.0.0
+			return $constraint_obj->matches($phpbb4_constraint) && !$constraint_obj->matches($phpbb3_constraint);
 		}
 		catch (\Exception $e)
 		{

--- a/contribution/extension/type.php
+++ b/contribution/extension/type.php
@@ -371,7 +371,15 @@ class type extends base
 		}
 
 		// Composer installers must be required by all extensions in order to be installed correctly
-		$data['require']['composer/installers'] = '~1.0.0';
+		if (!isset($data['require']['composer/installers']))
+		{
+			$installers_version = '~1.0';
+			if (isset($data['require']['phpbb/phpbb']) && $this->requires_phpbb_4_or_higher($data['require']['phpbb/phpbb']))
+			{
+				$installers_version = '^1.0 || ^2.0';
+			}
+			$data['require']['composer/installers'] = $installers_version;
+		}
 
 		return $data;
 	}
@@ -385,6 +393,27 @@ class type extends base
 	protected function is_stable_version($version)
 	{
 		return preg_match('#^\d+\.\d+\.\d+(-pl\d+)?$#i', $version) === 1 && phpbb_version_compare($version, '1.0.0', '>=');
+	}
+
+	/**
+	 * Check if phpBB requirement allows 4.0.0 or higher
+	 *
+	 * @param string $constraint Version constraint
+	 * @return bool True if constraint allows phpBB 4.0.0+
+	 */
+	protected function requires_phpbb_4_or_higher($constraint)
+	{
+		try
+		{
+			$parser = new \Composer\Semver\VersionParser();
+			$constraintObj = $parser->parseConstraints($constraint);
+			// Check if the constraint excludes versions below 4.0.0 by testing if 3.9.9 does NOT satisfy the constraint
+			return !$constraintObj->matches(new \Composer\Semver\Constraint\Constraint('==', '3.9.9.0'));
+		}
+		catch (\Exception $e)
+		{
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Titania is brute-force overwriting the composer/installers settings of every submitted extension. This should not be happening, unless the parameter is not already present in the submitted extension.

So if a user submits an extension with `"composer/installers": "~2.0"` Titania is overwriting that and knocking it back down to `"composer/installers": "~1.0.0"`. This is not good, and is also gonna guarantee no extensions will ever be installable via the phpBB4 extension catalog. 😂

This change will only add `composer/installers` if not already present in the extension. Also, if the extension submitted is phpBB4 compatible, then it will use `^1.0 || ^2.0` composer installers to ensure it shows up and is installable in the extension catalog (this is based on examining the ext's composer.json phpbb version constraints and the phpBB branch it was submitted to).