### PR TITLE
Fix minimum PHP version for titania

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     ],
     "require": {
         "ext-zip": "*",
-        "php": "^7.4.33",
+        "php": "^7.2",
         "phpbb/epv": "dev-master@dev",
         "phpbb/translation-validator": "~1.6",
         "composer/installers": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9334fe2f15432d8f51a05475edcdbde",
+    "content-hash": "58b55c8949c633f3a172b3e1bf2d930a",
     "packages": [
         {
             "name": "battye/php-array-parser",
@@ -2013,7 +2013,7 @@
     "prefer-lowest": false,
     "platform": {
         "ext-zip": "*",
-        "php": "^7.4.33"
+        "php": "^7.2"
     },
     "platform-dev": {},
     "platform-overrides": {


### PR DESCRIPTION
PHP 7.4 is not even required here so why shoot ourselves in the foot?