### PR TITLE
Validator can approve or deny using the queue’s robot

### DIFF
--- a/controller/manage/queue/item.php
+++ b/controller/manage/queue/item.php
@@ -393,7 +393,8 @@ class item extends \phpbb\titania\controller\manage\base
 
 		if ($this->validate('approve'))
 		{
-			$this->queue->approve($public_notes);
+			$robot_user_id = $this->contrib->type->forum_robot;
+			$this->queue->approve($public_notes, $robot_user_id);
 
 			// Reload contribution with new data.
 			$this->contrib->load();
@@ -433,7 +434,8 @@ class item extends \phpbb\titania\controller\manage\base
 	{
 		if ($this->validate('deny'))
 		{
-			$this->queue->deny();
+			$robot_user_id = $this->contrib->type->forum_robot;
+			$this->queue->deny($robot_user_id);
 			$this->contrib->type->deny($this->contrib, $this->queue, $this->request);
 			redirect($this->queue->get_url());
 		}

--- a/controller/manage/queue/item.php
+++ b/controller/manage/queue/item.php
@@ -390,10 +390,11 @@ class item extends \phpbb\titania\controller\manage\base
 	public function approve()
 	{
 		$public_notes = $this->request->variable('public_notes', '', true);
+		$post_as_robot = $this->request->variable('post_as_robot', 1);
 
 		if ($this->validate('approve'))
 		{
-			$robot_user_id = $this->contrib->type->forum_robot;
+			$robot_user_id = $post_as_robot ? $this->contrib->type->forum_robot : 0;
 			$this->queue->approve($public_notes, $robot_user_id);
 
 			// Reload contribution with new data.
@@ -432,9 +433,11 @@ class item extends \phpbb\titania\controller\manage\base
 	*/
 	public function deny()
 	{
+		$post_as_robot = $this->request->variable('post_as_robot', 1);
+
 		if ($this->validate('deny'))
 		{
-			$robot_user_id = $this->contrib->type->forum_robot;
+			$robot_user_id = $post_as_robot ? $this->contrib->type->forum_robot : 0;
 			$this->queue->deny($robot_user_id);
 			$this->contrib->type->deny($this->contrib, $this->queue, $this->request);
 			redirect($this->queue->get_url());
@@ -476,12 +479,19 @@ class item extends \phpbb\titania\controller\manage\base
 		$this->contrib->type->display_validation_options($action, $this->request, $this->template);
 		$this->display_topic_review();
 
+		$post_as_robot = $this->request->variable('post_as_robot', 1);
+		$has_robot = !empty($this->contrib->type->forum_robot);
+
 		$this->template->assign_vars(array(
 			'ERROR'						=> implode('<br />', $error),
 			'L_TOPIC_REVIEW'			=> $this->user->lang['QUEUE_REVIEW'],
 			'TOPIC_TITLE'				=> $this->contrib->contrib_name,
 			'PAGE_TITLE_EXPLAIN'		=> $this->user->lang[strtoupper($action) . '_QUEUE_CONFIRM'],
 			'S_CONFIRM_ACTION'			=> $this->queue->get_url($action),
+			'S_SHOW_POST_AS_OPTION'		=> $has_robot,
+			'POST_AS_ROBOT'				=> $post_as_robot,
+			'POST_AS_LABEL'				=> $this->user->lang['POST_AS_' . strtoupper($action)],
+			'ROBOT_NAME'				=> ucfirst($this->contrib->type->name),
 		));
 
 		return false;

--- a/controller/manage/queue/item.php
+++ b/controller/manage/queue/item.php
@@ -481,6 +481,7 @@ class item extends \phpbb\titania\controller\manage\base
 
 		$post_as_robot = $this->request->variable('post_as_robot', 1);
 		$has_robot = !empty($this->contrib->type->forum_robot);
+		$robot_name = $has_robot ? \users_overlord::get_user($this->contrib->type->forum_robot, 'username', true) : '';
 
 		$this->template->assign_vars(array(
 			'ERROR'						=> implode('<br />', $error),
@@ -488,10 +489,10 @@ class item extends \phpbb\titania\controller\manage\base
 			'TOPIC_TITLE'				=> $this->contrib->contrib_name,
 			'PAGE_TITLE_EXPLAIN'		=> $this->user->lang[strtoupper($action) . '_QUEUE_CONFIRM'],
 			'S_CONFIRM_ACTION'			=> $this->queue->get_url($action),
-			'S_SHOW_POST_AS_OPTION'		=> $has_robot,
+			'S_SHOW_POST_AS_OPTION'		=> $has_robot && $robot_name,
 			'POST_AS_ROBOT'				=> $post_as_robot,
+			'ROBOT_NAME'				=> $robot_name,
 			'POST_AS_LABEL'				=> $this->user->lang['POST_AS_' . strtoupper($action)],
-			'ROBOT_NAME'				=> ucfirst($this->contrib->type->name),
 		));
 
 		return false;

--- a/controller/manage/queue/item.php
+++ b/controller/manage/queue/item.php
@@ -394,7 +394,8 @@ class item extends \phpbb\titania\controller\manage\base
 
 		if ($this->validate('approve'))
 		{
-			$robot_user_id = $post_as_robot ? $this->contrib->type->forum_robot : 0;
+			$robot_user = $post_as_robot ? $this->get_robot_user() : false;
+			$robot_user_id = $robot_user ? (int) $robot_user['user_id'] : 0;
 			$this->queue->approve($public_notes, $robot_user_id);
 
 			// Reload contribution with new data.
@@ -437,7 +438,8 @@ class item extends \phpbb\titania\controller\manage\base
 
 		if ($this->validate('deny'))
 		{
-			$robot_user_id = $post_as_robot ? $this->contrib->type->forum_robot : 0;
+			$robot_user = $post_as_robot ? $this->get_robot_user() : false;
+			$robot_user_id = $robot_user ? (int) $robot_user['user_id'] : 0;
 			$this->queue->deny($robot_user_id);
 			$this->contrib->type->deny($this->contrib, $this->queue, $this->request);
 			redirect($this->queue->get_url());
@@ -480,8 +482,8 @@ class item extends \phpbb\titania\controller\manage\base
 		$this->display_topic_review();
 
 		$post_as_robot = $this->request->variable('post_as_robot', 1);
-		$has_robot = !empty($this->contrib->type->forum_robot);
-		$robot_name = $has_robot ? \users_overlord::get_user($this->contrib->type->forum_robot, 'username', true) : '';
+		$robot_user = $this->get_robot_user();
+		$robot_name = $robot_user ? $robot_user['username'] : '';
 
 		$this->template->assign_vars(array(
 			'ERROR'						=> implode('<br />', $error),
@@ -489,13 +491,29 @@ class item extends \phpbb\titania\controller\manage\base
 			'TOPIC_TITLE'				=> $this->contrib->contrib_name,
 			'PAGE_TITLE_EXPLAIN'		=> $this->user->lang[strtoupper($action) . '_QUEUE_CONFIRM'],
 			'S_CONFIRM_ACTION'			=> $this->queue->get_url($action),
-			'S_SHOW_POST_AS_OPTION'		=> $has_robot && $robot_name,
+			'S_SHOW_POST_AS_OPTION'		=> (bool) $robot_name,
 			'POST_AS_ROBOT'				=> $post_as_robot,
 			'ROBOT_NAME'				=> $robot_name,
 			'POST_AS_LABEL'				=> $this->user->lang['POST_AS_' . strtoupper($action)],
 		));
 
 		return false;
+	}
+
+	/**
+	* Get the validated robot user row, or false if forum_robot is unset or resolves to the anonymous user.
+	*
+	* @return array|false
+	*/
+	protected function get_robot_user()
+	{
+		if (empty($this->contrib->type->forum_robot))
+		{
+			return false;
+		}
+
+		$robot_user = \users_overlord::get_user($this->contrib->type->forum_robot, false, true);
+		return ($robot_user && $robot_user['user_id'] != ANONYMOUS) ? $robot_user : false;
 	}
 
 	/**

--- a/includes/objects/queue.php
+++ b/includes/objects/queue.php
@@ -569,9 +569,18 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		$message_uid = $message_bitfield = $message_options = false;
 		generate_text_for_storage($message, $message_uid, $message_bitfield, $message_options, true, true, true);
 
-		$sender_id = $robot_user_id ?: phpbb::$user->data['user_id'];
-		$sender_name = users_overlord::get_user($sender_id, 'username', true);
-		$sender_ip = $robot_user_id ? '' : phpbb::$user->ip;
+		if ($robot_user_id)
+		{
+			$sender_id = $robot_user_id;
+			$sender_name = users_overlord::get_user($robot_user_id, 'username', true);
+			$sender_ip = '';
+		}
+		else
+		{
+			$sender_id = phpbb::$user->data['user_id'];
+			$sender_name = phpbb::$user->data['username'];
+			$sender_ip = phpbb::$user->ip;
+		}
 
 		$data = array(
 			'address_list'		=> array('u' => $authors),

--- a/includes/objects/queue.php
+++ b/includes/objects/queue.php
@@ -230,9 +230,10 @@ class titania_queue extends \phpbb\titania\entity\message_base
 	*
 	* @param string $message
 	* @param bool $teams_only true to set to access level of teams
+	* @param int $post_user_id User ID to use for the post (defaults to current user)
 	* @return \titania_post Returns post object.
 	*/
-	public function topic_reply($message, $teams_only = true)
+	public function topic_reply($message, $teams_only = true, $post_user_id = 0)
 	{
 		$this->user->add_lang_ext('phpbb/titania', 'manage');
 
@@ -247,6 +248,11 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		if ($teams_only)
 		{
 			$post->post_access = access::TEAM_LEVEL;
+		}
+
+		if ($post_user_id)
+		{
+			$post->post_user_id = (int) $post_user_id;
 		}
 
 		$post->parent_contrib_type = $this->queue_type;
@@ -384,8 +390,9 @@ class titania_queue extends \phpbb\titania\entity\message_base
 	* Approve this revision
 	*
 	* @param mixed $public_notes
+	* @param int $robot_user_id User ID to use for posts/messages (defaults to current user)
 	*/
-	public function approve($public_notes)
+	public function approve($public_notes, $robot_user_id = 0)
 	{
 		$this->user->add_lang_ext('phpbb/titania', array('manage', 'contributions'));
 		$revision = $this->get_revision();
@@ -407,8 +414,8 @@ class titania_queue extends \phpbb\titania\entity\message_base
 			$message = str_replace('[quote][/quote]', '', $message);
 		}
 
-		$this->topic_reply($message, false);
-		$this->discussion_reply($message);
+		$this->topic_reply($message, false, $robot_user_id);
+		$this->discussion_reply($message, false, $robot_user_id);
 
 		// Get branch information first
 		$version_branches = array();
@@ -430,13 +437,13 @@ class titania_queue extends \phpbb\titania\entity\message_base
 			{
 				// Replying to an already existing topic, use the update message
 				$post_public_notes = sprintf(phpbb::$user->lang[$contrib->type->update_public], $revision->revision_version) . (($public_notes) ? sprintf(phpbb::$user->lang[$contrib->type->update_public . '_NOTES'], $public_notes) : '');
-				$contrib->reply_release_topic($branch, $post_public_notes);
+				$contrib->reply_release_topic($branch, $post_public_notes, array('poster_id' => $robot_user_id));
 			}
 			elseif (!$contrib_release_topic_id && $contrib->type->reply_public)
 			{
 				// Replying to a topic that was just made, use the reply message
 				$post_public_notes = phpbb::$user->lang[$contrib->type->reply_public] . (($public_notes) ? sprintf(phpbb::$user->lang[$contrib->type->reply_public . '_NOTES'], $public_notes) : '');
-				$contrib->reply_release_topic($branch, $post_public_notes);
+				$contrib->reply_release_topic($branch, $post_public_notes, array('poster_id' => $robot_user_id));
 			}
 		}
 
@@ -447,7 +454,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		$this->submit(false);
 
 		// Send notification message
-		$this->send_approve_deny_notification(true);
+		$this->send_approve_deny_notification(true, $robot_user_id);
 
 		// Subscriptions
 		$email_vars = array(
@@ -474,7 +481,7 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		$this->trash_queue_topic();
 	}
 
-	public function deny()
+	public function deny($robot_user_id = 0)
 	{
 		// Reply to the queue topic and discussion with the message
 		$this->user->add_lang_ext('phpbb/titania', 'manage');
@@ -490,8 +497,8 @@ class titania_queue extends \phpbb\titania\entity\message_base
 			$message = str_replace('[quote][/quote]', '', $message);
 		}
 
-		$this->topic_reply($message, false);
-		$this->discussion_reply($message);
+		$this->topic_reply($message, false, $robot_user_id);
+		$this->discussion_reply($message, false, $robot_user_id);
 
 		// Update the revision
 		$revision->change_status(ext::TITANIA_REVISION_DENIED);
@@ -503,15 +510,17 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		$this->submit(false);
 
 		// Send notification message
-		$this->send_approve_deny_notification(false);
+		$this->send_approve_deny_notification(false, $robot_user_id);
 
 		$this->trash_queue_topic();
 	}
 
 	/**
 	* Send the approve/deny notification
+	* @param bool $approve
+	* @param int $robot_user_id User ID to use as sender (defaults to current user)
 	*/
-	private function send_approve_deny_notification($approve = true)
+	private function send_approve_deny_notification($approve = true, $robot_user_id = 0)
 	{
 		$this->user->add_lang_ext('phpbb/titania', 'manage');
 		phpbb::_include('functions_privmsgs', 'submit_pm');
@@ -560,12 +569,16 @@ class titania_queue extends \phpbb\titania\entity\message_base
 		$message_uid = $message_bitfield = $message_options = false;
 		generate_text_for_storage($message, $message_uid, $message_bitfield, $message_options, true, true, true);
 
+		$sender_id = $robot_user_id ?: phpbb::$user->data['user_id'];
+		$sender_name = users_overlord::get_user($sender_id, 'username', true);
+		$sender_ip = $robot_user_id ? '' : phpbb::$user->ip;
+
 		$data = array(
 			'address_list'		=> array('u' => $authors),
-			'from_user_id'		=> phpbb::$user->data['user_id'],
-			'from_username'		=> phpbb::$user->data['username'],
+			'from_user_id'		=> $sender_id,
+			'from_username'		=> $sender_name,
 			'icon_id'			=> 0,
-			'from_user_ip'		=> phpbb::$user->ip,
+			'from_user_ip'		=> $sender_ip,
 			'enable_bbcode'		=> true,
 			'enable_smilies'	=> true,
 			'enable_urls'		=> true,

--- a/language/en/manage.php
+++ b/language/en/manage.php
@@ -84,6 +84,10 @@ $lang = array_merge($lang, array(
 	'OPEN_ITEMS'				=> 'Open Items',
 
 	'PLEASE_WAIT_FOR_TOOL'		=> 'Please wait for the tool to finish running.',
+	'POST_AS_APPROVE'			=> 'Approve as',
+	'POST_AS_DENY'				=> 'Deny as',
+	'POST_AS_ROBOT'				=> '%s Robot',
+	'POST_AS_SELF'				=> 'Yourself',
 	'PUBLIC_NOTES'				=> 'Public release notes',
 
 	'QUEUE_APPROVE'				=> 'Awaiting Approval',

--- a/language/en/manage.php
+++ b/language/en/manage.php
@@ -86,7 +86,6 @@ $lang = array_merge($lang, array(
 	'PLEASE_WAIT_FOR_TOOL'		=> 'Please wait for the tool to finish running.',
 	'POST_AS_APPROVE'			=> 'Approve as',
 	'POST_AS_DENY'				=> 'Deny as',
-	'POST_AS_ROBOT'				=> '%s Robot',
 	'POST_AS_SELF'				=> 'Yourself',
 	'PUBLIC_NOTES'				=> 'Public release notes',
 

--- a/styles/prosilver/template/manage/queue_validate.html
+++ b/styles/prosilver/template/manage/queue_validate.html
@@ -31,7 +31,7 @@
 		<dl>
 			<dt style="width: auto"><label>{{ POST_AS_LABEL ~ lang('COLON') }}</label></dt>
 			<dd style="margin: 0 0 12px 10%">
-				<label><input type="radio" name="post_as_robot" value="1"{% if POST_AS_ROBOT %} checked="checked"{% endif %} />{{ lang('POST_AS_ROBOT', ROBOT_NAME) }}</label>
+				<label><input type="radio" name="post_as_robot" value="1"{% if POST_AS_ROBOT %} checked="checked"{% endif %} />{{ ROBOT_NAME }}</label>
 				<label><input type="radio" name="post_as_robot" value="0"{% if not POST_AS_ROBOT %} checked="checked"{% endif %} />{{ lang('POST_AS_SELF') }}</label>
 			</dd>
 		</dl>

--- a/styles/prosilver/template/manage/queue_validate.html
+++ b/styles/prosilver/template/manage/queue_validate.html
@@ -26,6 +26,18 @@
 	<h2>{{ PAGE_TITLE }}</h2>
 	<p>{{ PAGE_TITLE_EXPLAIN }}</p>
 
+	{% if S_SHOW_POST_AS_OPTION %}
+	<fieldset>
+		<dl>
+			<dt><label>{{ POST_AS_LABEL ~ lang('COLON') }}</label></dt>
+			<dd>
+				<label><input type="radio" name="post_as_robot" value="1"{% if POST_AS_ROBOT %} checked="checked"{% endif %} /> {{ lang('POST_AS_ROBOT', ROBOT_NAME) }}</label>
+				<label><input type="radio" name="post_as_robot" value="0"{% if not POST_AS_ROBOT %} checked="checked"{% endif %} /> {{ lang('POST_AS_SELF') }}</label>
+			</dd>
+		</dl>
+	</fieldset>
+	{% endif %}
+
 	<fieldset>
 		{% if S_STYLE_DEMO_INSTALL %}
 		<dl>

--- a/styles/prosilver/template/manage/queue_validate.html
+++ b/styles/prosilver/template/manage/queue_validate.html
@@ -29,10 +29,10 @@
 	{% if S_SHOW_POST_AS_OPTION %}
 	<fieldset>
 		<dl>
-			<dt><label>{{ POST_AS_LABEL ~ lang('COLON') }}</label></dt>
-			<dd>
-				<label><input type="radio" name="post_as_robot" value="1"{% if POST_AS_ROBOT %} checked="checked"{% endif %} /> {{ lang('POST_AS_ROBOT', ROBOT_NAME) }}</label>
-				<label><input type="radio" name="post_as_robot" value="0"{% if not POST_AS_ROBOT %} checked="checked"{% endif %} /> {{ lang('POST_AS_SELF') }}</label>
+			<dt style="width: auto"><label>{{ POST_AS_LABEL ~ lang('COLON') }}</label></dt>
+			<dd style="margin: 0 0 12px 10%">
+				<label><input type="radio" name="post_as_robot" value="1"{% if POST_AS_ROBOT %} checked="checked"{% endif %} />{{ lang('POST_AS_ROBOT', ROBOT_NAME) }}</label>
+				<label><input type="radio" name="post_as_robot" value="0"{% if not POST_AS_ROBOT %} checked="checked"{% endif %} />{{ lang('POST_AS_SELF') }}</label>
 			</dd>
 		</dl>
 	</fieldset>


### PR DESCRIPTION
<img width="443" height="170" alt="Screenshot 2026-02-22 at 5 59 52 PM" src="https://github.com/user-attachments/assets/291697af-656f-4c5e-9085-242e4b3a2209" />

<img width="367" height="106" alt="Screenshot 2026-02-22 at 6 08 22 PM" src="https://github.com/user-attachments/assets/653b4b1b-4289-469d-b458-b3a7818bd070" />

Queue approvals and denials now post as the queue robot account by default for consistency (if the robot exists), with validators able to optionally choose to post under their own username via a radio button on the approval/denial form.