### PR TITLE
Build filtered repository parents from their own include files

### DIFF
--- a/composer/repository.php
+++ b/composer/repository.php
@@ -180,16 +180,17 @@ class repository
 	/**
 	 * Get include files.
 	 *
+	 * @param string $subdir Optional subdirectory
 	 * @return Finder
 	 */
-	protected function get_include_files()
+	protected function get_include_files($subdir = '')
 	{
 		$finder = new Finder;
 		$finder
 			->files()
 			->depth('== 0')
 			->name('/^packages\-[a-z]+\-\d+\.json$/')
-			->in($this->build_dir)
+			->in($this->build_dir . $subdir)
 		;
 
 		return $finder;
@@ -215,7 +216,7 @@ class repository
 	 */
 	protected function build_parent_structure($subdir = '')
 	{
-		$includes = $this->get_include_files();
+		$includes = $this->get_include_files($subdir);
 		$parent = $types = array();
 		$target_dir = $this->build_dir . $subdir;
 


### PR DESCRIPTION
Follow-up to #406. The parent files under `composer_packages/<branch>/` are built from the include files in the build root instead of the ones in that directory, so `/composer/40/` advertises sha1 hashes that belong to the unfiltered package list.

`build_parent_structure()` takes a `$subdir` and writes `packages-<type>.json` into it, but `get_include_files()` always scanned `$this->build_dir`. Composer resolves includes relative to the repository URL, so a client reading `/composer/40/packages-extension.json` is told to expect the root file's hash and is then served the branch-filtered file. The two only agree when the filtered subset happens to equal the full set, which is probably why this has not come up.

Nothing fails outright. Composer 2 uses the hash as a cache-freshness check in `ComposerRepository::loadIncludes()` and falls back to an unvalidated `fetchFile()`, so the effect is that the check can never succeed: the 4.0 repository's include metadata is re-downloaded on every resolution, and the published checksums do not describe what is being served.

Reproduced on a local board with two approved extension contributions, one with a 3.3 revision and one with a 4.0 revision:

```
$ php bin/phpbbcli.php titania:composer:rebuild_repo --force
$ cat composer_packages/prod/40/packages-extension.json
{"includes":{"packages-extension-1.json":{"sha1":"6bdacf909285696c882e31e228b93582fbeccc55"}}}
$ sha1sum composer_packages/prod/40/packages-extension-1.json
930ceb04cb6d9f52925659d8a399fbcf2d6549ac
```

With this change both the root and the `40/` parent list the hash of the file served alongside them, and the branch filtering is unchanged. Checked with a real `composer update` against `/composer/40/`: it resolves the 4.0 package, still refuses a 3.3-only one, and the include is a cache hit on the second run rather than a re-download. `phpcs` with `ruleset-php-extensions.xml` is clean on the changed file.

I could not confirm the behaviour against the live site since the composer endpoints are behind the bot challenge, so that part is inference from the code rather than a measurement.
