### PR TITLE
Allow emoji in attention titles and descriptions

### DIFF
--- a/includes/objects/attention.php
+++ b/includes/objects/attention.php
@@ -111,6 +111,12 @@ class titania_attention extends \phpbb\titania\entity\database_base
 			);
 		}
 
+		// Emojis and other four byte characters are not allowed by MySQL in the
+		// utf8 columns these are stored in, so replace them with their numeric
+		// character reference, as core does for report text.
+		$this->attention_title = utf8_encode_ucr($this->attention_title);
+		$this->attention_description = utf8_encode_ucr($this->attention_description);
+
 		parent::submit();
 	}
 


### PR DESCRIPTION
Fixes #371.

Reporting a post or a contribution writes the subject and the reason straight into `attention_title` and `attention_description`. Unlike the message fields these never pass through the text formatter, so a four byte character such as an emoji reaches the `utf8` columns as-is and MySQL rejects the row:

```
Incorrect string value: '\xF0\x9F\x86\x95 t...' for column 'attention_title' at row 1 [1366]
```

This uses `utf8_encode_ucr()` on the way in, the same thing core does to report text in `phpbb\report\controller\report`, per @iMattPro's suggestion on #390. Doing it in `titania_attention::submit()` covers all three places that create attention rows rather than patching each one.

Nothing needs decoding on the way out, since a character reference renders as the character it stands for.

Checked on a local board:

- reporting with an emoji in the subject and in the reason now succeeds
- four byte characters outside the emoji range are handled too, a rare CJK ideograph encodes the same way
- accented characters are left alone, only four byte sequences are touched
- plain text is unchanged, and rows written before this change read back exactly as before
- the encoding is stable, so a caller passing text that already carries a character reference does not end up with it encoded twice
- closing a report does not re-encode it

The columns could instead be moved to `utf8mb4`, but the driver connects with `SET NAMES 'utf8'`, so the insert still fails at the connection before the column charset applies. That is PHPBB-16137, still awaiting review.
