### PR TITLE
Allow emoji in contribution names

### DIFF
--- a/includes/objects/contribution.php
+++ b/includes/objects/contribution.php
@@ -1640,9 +1640,7 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 	*/
 	public function generate_permalink()
 	{
-		// Drop any character references left by utf8_encode_ucr() rather than
-		// letting their digits end up in the permalink.
-		$clean_name = url::generate_slug(preg_replace('/&#[0-9]+;/', '', $this->contrib_name));
+		$clean_name = url::generate_slug($this->contrib_name);
 		$append = '';
 		$i = 2;
 		while ($this->permalink_exists($clean_name . $append))

--- a/includes/objects/contribution.php
+++ b/includes/objects/contribution.php
@@ -1091,6 +1091,13 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 	 */
 	public function submit()
 	{
+		// Emojis and other four byte characters are not allowed by MySQL in the
+		// utf8 column the name is stored in, so replace them with their numeric
+		// character reference, as core does for report text. Doing it here keeps
+		// the encoded form out of everything that reads the name, including the
+		// release topic subject and the generated slug.
+		$this->contrib_name = utf8_encode_ucr($this->contrib_name);
+
 		if (!$this->contrib_id)
 		{
 			// Make sure the author exists, if not we create one (do this before returning if not approved...else we need to duplicate this code in a bunch of places)
@@ -1633,7 +1640,9 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 	*/
 	public function generate_permalink()
 	{
-		$clean_name = url::generate_slug($this->contrib_name);
+		// Drop any character references left by utf8_encode_ucr() rather than
+		// letting their digits end up in the permalink.
+		$clean_name = url::generate_slug(preg_replace('/&#[0-9]+;/', '', $this->contrib_name));
 		$append = '';
 		$i = 2;
 		while ($this->permalink_exists($clean_name . $append))

--- a/url/url.php
+++ b/url/url.php
@@ -192,6 +192,13 @@ class url
 	 */
 	public static function generate_slug($string)
 	{
+		// Neither a character reference nor a character outside the basic
+		// multilingual plane belongs in a slug: the columns slugs are stored in
+		// are utf8, which cannot hold the latter, and the digits of the former
+		// would end up in the URL.
+		$string = preg_replace('/&#[0-9]+;/', '', $string);
+		$string = preg_replace('/[\x{10000}-\x{10FFFF}]/u', '', $string);
+
 		$string = self::url_replace($string, false);
 
 		// Replace any number of spaces with a single underscore


### PR DESCRIPTION
Picks up #390, which has been sitting as a draft since 2022. The diagnosis there is @battye's, and the approach here is @iMattPro's suggestion on that thread.

A four byte character in a contribution name reaches the `utf8` column as-is and MySQL rejects the row, on create and on edit both:

```
Incorrect string value: '\xF0\x9F\x86\x95 E...' for column 'contrib_name' at row 1 [1366]
```

`utf8_encode_ucr()` replaces those characters with their numeric character reference, the same thing core does to report text in `phpbb\report\controller\report`. Encoding in `titania_contribution::submit()` rather than in the controllers covers create and edit together, and keeps the stored form out of everything that reads the name, so nothing has to decode it.

That last part is why this does not take the approach in #390. Parsing the name leaves s9e markup in the field, which then reaches the queue topic subject, and @battye ran into exactly that in June 2024:

```
Incorrect string value ... for column 'topic_subject' at row 1 [1366]
'Validation - &lt;r&gt;Test edit: &lt;EMOJI seq=&quot;1f195&quot;...'
```

A character reference has neither problem. Dropping them when generating a permalink keeps the digits out of the URL, otherwise the slug comes out as `cool_127381;_extension`.

Checked on a local board:

- creating and editing with an emoji in the name both succeed
- the release topic subject stores fine and stays within the column
- the permalink comes out as `cool_extension`
- four byte characters outside the emoji range are handled too, a rare CJK ideograph encodes the same way
- accented characters are untouched, only four byte sequences are touched
- re-saving does not encode twice, and names stored before this change are unaffected

#439 fixes the attention fields, which fail the same way, using the same function.

If @battye would rather carry this on #390 then I am happy for this to be closed in favour of it.
