### PR TITLE
Fix the style demo installation

### DIFF
--- a/contribution/style/demo/manager.php
+++ b/contribution/style/demo/manager.php
@@ -32,6 +32,9 @@ class manager
 	/** @var \phpbb\db\db_interface */
 	protected $db;
 
+	/** @var string */
+	protected $table_prefix;
+
 	/** @var int */
 	protected $branch;
 
@@ -151,9 +154,18 @@ class manager
 
 		$hook_url = $this->ext_config->demo_style_hook[$this->branch];
 		$context = stream_context_create($options);
-		$result = file_get_contents($hook_url, false, $context, 0, 50);
+		// A failing hook must degrade to an error result; the warning would
+		// otherwise be turned into an exception and lose the JSON reply.
+		$result = @file_get_contents($hook_url, false, $context, 0, 50);
 		$this->delete_auth_key($key);
 
+		if ($result === false)
+		{
+			return array(
+				'id'	=> 0,
+				'error'	=> $this->user->lang('UNKNOWN_ERROR'),
+			);
+		}
 		return $this->get_result($result);
 	}
 

--- a/contribution/style/type.php
+++ b/contribution/style/type.php
@@ -208,16 +208,24 @@ class type extends base
 
 		$demo_url = '';
 
-		if ($this->demo_manager->configure($branch, $contrib, $package))
+		// A demo failure must not abort the approval or the AJAX reply.
+		try
 		{
-			$result = $this->demo_manager->install();
-
-			if (empty($result['error']))
+			if ($this->demo_manager->configure($branch, $contrib, $package))
 			{
-				$demo_url = $this->demo_manager->get_demo_url($branch, $result['id']);
-				$contrib->set_demo_url($branch, $demo_url);
-				$contrib->submit();
+				$result = $this->demo_manager->install();
+
+				if (empty($result['error']))
+				{
+					$demo_url = $this->demo_manager->get_demo_url($branch, $result['id']);
+					$contrib->set_demo_url($branch, $demo_url);
+					$contrib->submit();
+				}
 			}
+		}
+		catch (\Throwable $e)
+		{
+			$demo_url = '';
 		}
 		$package->cleanup();
 

--- a/controller/contribution/manage.php
+++ b/controller/contribution/manage.php
@@ -629,6 +629,14 @@ class manage extends base
 			$revision->__set_array($this->contrib->download[$branch]);
 			$demo_url = $this->contrib->type->install_demo($this->contrib, $revision);
 		}
+
+		if ($demo_url === '')
+		{
+			return array(
+				'MESSAGE_TITLE'	=> $this->user->lang('INFORMATION'),
+				'MESSAGE_TEXT'	=> $this->user->lang('DEMO_INSTALL_FAILED'),
+			);
+		}
 		return array(
 			'url'	=> $demo_url,
 		);

--- a/language/en/contributions.php
+++ b/language/en/contributions.php
@@ -101,6 +101,7 @@ $lang = array_merge($lang, array(
 	'DELETE_CONTRIBUTION_EXPLAIN'			=> 'Permanently remove this contribution (use the contribution status field if you need to hide it).',
 	'DELETE_REVISION'						=> 'Delete Revision',
 	'DELETE_REVISION_EXPLAIN'				=> 'Permanently remove this revision (use the revision status field if you need to hide it).',
+	'DEMO_INSTALL_FAILED'					=> 'The style could not be installed on the demo board.',
 	'DEMO_URL'								=> 'Demo URL',
 	'DEMO_URL_EXPLAIN'						=> 'Location of the demonstration',
 	'DEPENDENCIES'							=> 'Dependencies',

--- a/misc/style_demo_hooks/phpBB_3.3.x/style_demo_install.php
+++ b/misc/style_demo_hooks/phpBB_3.3.x/style_demo_install.php
@@ -20,6 +20,12 @@ include($phpbb_root_path . 'includes/acp/acp_styles.' . $phpEx);
 include($phpbb_root_path . 'includes/style_demo_manager.' . $phpEx);
 include($phpbb_root_path . 'includes/style_demo_hook.' . $phpEx);
 
+// acp_styles logs the installation and reads the user's id and ip from the
+// session, so one has to exist before the manager runs.
+$user->session_begin();
+$auth->acl($user->data);
+$user->setup();
+
 $hook = new \titania_style_demo_hook($config, $db, $user, $phpbb_root_path, $phpEx);
 $result = $hook->run($request->variable('key', ''));
 

--- a/misc/style_demo_hooks/style_demo_hook.php
+++ b/misc/style_demo_hooks/style_demo_hook.php
@@ -25,6 +25,9 @@ class titania_style_demo_hook
 	/** @var string */
 	protected $php_ext;
 
+	/** @var titania_demo_manager */
+	protected $manager;
+
 	/**
 	* Constructor.
 	*


### PR DESCRIPTION
Fixes #410

The demo board hook fatals during installation: acp_styles logs the install through $phpbb_log->add() using the session's user id and ip, and style_demo_install.php never starts a session. The hook predates that core change (phpBB 3.2.0, ticket 13468), add_log() used to guard against an empty user. The style row is committed before the fatal, so retries appear to work.

The hook now starts a session first, a failed hook call degrades to the existing error result, the install button answers with a proper message when no URL was produced, and a demo failure can no longer abort the approval.

Note the live hook's auth phase responds fine, so if the install still fails on phpbb.com after this, the remaining cause is in the install leg (paths, database access or Cloudflare between the servers) and will now be visible in the logs instead of an AJAX error.