### PR TITLE
Keep relative links working after loading a category in place

### DIFF
--- a/assets/javascript/ajax.js
+++ b/assets/javascript/ajax.js
@@ -70,11 +70,17 @@
 		// The address is about to change directory depth, which would make the
 		// browser re-resolve every relative URL on the page against the new
 		// path. Pin them to the URL the document was rendered against first.
-		$('a[href^="./"], form[action^="./"]').each(function() {
+		var resolver = document.createElement('a');
+		$('a[href], form[action]').each(function() {
 			var name = (this.nodeName === 'FORM') ? 'action' : 'href',
-				resolver = document.createElement('a');
+				value = this.getAttribute(name);
 
-			resolver.href = this.getAttribute(name);
+			// Skip absolute URLs, protocol-relative URLs, root-relative URLs, and in-page anchors.
+			if (!value || value[0] === '#' || value[0] === '/' || value.indexOf('//') === 0 || /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value)) {
+				return;
+			}
+
+			resolver.href = value;
 			this.setAttribute(name, resolver.href);
 		});
 

--- a/assets/javascript/ajax.js
+++ b/assets/javascript/ajax.js
@@ -67,6 +67,17 @@
 			$contribList = $('.contrib-list-container'),
 			$search = $('#category-search');
 
+		// The address is about to change directory depth, which would make the
+		// browser re-resolve every relative URL on the page against the new
+		// path. Pin them to the URL the document was rendered against first.
+		$('a[href^="./"], form[action^="./"]').each(function() {
+			var name = (this.nodeName === 'FORM') ? 'action' : 'href',
+				resolver = document.createElement('a');
+
+			resolver.href = this.getAttribute(name);
+			this.setAttribute(name, resolver.href);
+		});
+
 		phpbb.history.replaceUrl($this.attr('href'));
 
 		var getParents = function($self) {


### PR DESCRIPTION
Fixes #370

The fix converts the page's relative links and form actions to full URLs before the address changes, so they keep working no matter what category is loaded.