### PR TITLE
Limit the demo box to branches with an approved revision

### DIFF
--- a/controller/contribution/base.php
+++ b/controller/contribution/base.php
@@ -172,7 +172,7 @@ class base
 		if ($this->contrib->contrib_demo)
 		{
 			$demo_menu = array();
-			$allowed_branches = $this->contrib->type->get_allowed_branches(true);
+			$allowed_branches = $this->contrib->get_approved_branches();
 			krsort($allowed_branches);
 			$is_external = $this->contrib->contrib_status != ext::TITANIA_CONTRIB_APPROVED || !$this->contrib->options['demo'];
 

--- a/controller/contribution/manage.php
+++ b/controller/contribution/manage.php
@@ -125,7 +125,7 @@ class manage extends base
 		);
 		$this->settings['custom'] = $this->contrib->get_custom_fields();
 
-		foreach ($this->contrib->type->get_allowed_branches(true) as $branch => $name)
+		foreach ($this->contrib->get_approved_branches() as $branch => $name)
 		{
 			$this->settings['demo'][$branch] = $this->contrib->get_demo_url($branch);
 		}
@@ -145,7 +145,7 @@ class manage extends base
 			));
 			$demos = $this->request->variable('demo', array(0 => ''));
 
-			foreach ($this->contrib->type->get_allowed_branches(true) as $branch => $name)
+			foreach ($this->contrib->get_approved_branches() as $branch => $name)
 			{
 				if (isset($demos[$branch]))
 				{
@@ -155,7 +155,8 @@ class manage extends base
 
 			$this->contrib->post_data($this->message);
 			$this->contrib->__set_array(array(
-				'contrib_demo'				=> ($this->can_edit_demo) ? json_encode($this->settings['demo']) : $this->contrib->contrib_demo,
+				// Preserve stored URLs for branches not open for editing.
+				'contrib_demo'				=> ($this->can_edit_demo) ? json_encode($this->settings['demo'] + $this->contrib->get_demo_urls()) : $this->contrib->contrib_demo,
 				'contrib_limited_support'	=> $this->settings['limited_support'],
 			));
 		}

--- a/includes/objects/contribution.php
+++ b/includes/objects/contribution.php
@@ -1036,6 +1036,38 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 	}
 
 	/**
+	* Get the branches for which the contribution has an approved revision.
+	*
+	* @return array Branch names limited to the branches that have an approved
+	*	revision, keyed by branch - example: 31 => 'phpBB 3.1.x'
+	*/
+	public function get_approved_branches()
+	{
+		$this->get_download();
+
+		return array_intersect_key(
+			$this->type->get_allowed_branches(true),
+			$this->download
+		);
+	}
+
+	/**
+	* Get all stored demo URLs.
+	*
+	* @return array Demo URLs keyed by branch - example: 31 => 'http://...'
+	*/
+	public function get_demo_urls()
+	{
+		if (empty($this->contrib_demo))
+		{
+			return array();
+		}
+		$demos = json_decode($this->contrib_demo, true);
+
+		return (is_array($demos)) ? $demos : array();
+	}
+
+	/**
 	* Get demo URL.
 	*
 	* @param int $branch			Branch - example: 30, 31
@@ -1045,11 +1077,7 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 	*/
 	public function get_demo_url($branch, $integrated_url = false)
 	{
-		if (empty($this->contrib_demo))
-		{
-			return '';
-		}
-		$demos = json_decode($this->contrib_demo, true);
+		$demos = $this->get_demo_urls();
 
 		if (empty($demos[$branch]))
 		{

--- a/includes/objects/contribution.php
+++ b/includes/objects/contribution.php
@@ -1041,57 +1041,57 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 	* @return array Branch names limited to the branches that have an approved
 	*	revision, keyed by branch - example: 31 => 'phpBB 3.1.x'
 	*/
-public function get_approved_branches()
-{
-	$allowed_branches = $this->type->get_allowed_branches(true);
-
-	$this->get_download();
-	if (!empty($this->download))
+	public function get_approved_branches()
 	{
-		return array_intersect_key($allowed_branches, $this->download);
-	}
+		$allowed_branches = $this->type->get_allowed_branches(true);
 
-	// get_download() may intentionally return early (e.g. downloads disabled for non-team)
-	// so fall back to checking which branches have an approved, validated revision.
-	$sql = 'SELECT DISTINCT(phpbb_version_branch), MAX(revision_id) AS revision_id
-		FROM ' . TITANIA_REVISIONS_PHPBB_TABLE . '
-		WHERE contrib_id = ' . (int) $this->contrib_id . '
-			AND revision_validated = 1
-		GROUP BY phpbb_version_branch';
-	$result = phpbb::$db->sql_query($sql);
-	$revisions = array();
-	while ($row = phpbb::$db->sql_fetchrow($result))
-	{
-		$revisions[(int) $row['phpbb_version_branch']] = (int) $row['revision_id'];
-	}
-	phpbb::$db->sql_freeresult($result);
-
-	if (empty($revisions))
-	{
-		return array();
-	}
-
-	$sql = 'SELECT revision_id
-		FROM ' . TITANIA_REVISIONS_TABLE . '
-		WHERE contrib_id = ' . (int) $this->contrib_id . '
-			AND ' . phpbb::$db->sql_in_set('revision_id', array_values($revisions)) . '
-			AND revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
-			AND revision_submitted = 1';
-	$result = phpbb::$db->sql_query($sql);
-	$revisions = array_flip($revisions); // revision_id => branch
-	$approved = array();
-	while ($row = phpbb::$db->sql_fetchrow($result))
-	{
-		$branch = (int) $revisions[(int) $row['revision_id']];
-		if (isset($allowed_branches[$branch]))
+		$this->get_download();
+		if (!empty($this->download))
 		{
-			$approved[$branch] = $allowed_branches[$branch];
+			return array_intersect_key($allowed_branches, $this->download);
 		}
-	}
-	phpbb::$db->sql_freeresult($result);
 
-	return $approved;
-}
+		// get_download() may intentionally return early (e.g. downloads disabled for non-team)
+		// so fall back to checking which branches have an approved, validated revision.
+		$sql = 'SELECT DISTINCT(phpbb_version_branch), MAX(revision_id) AS revision_id
+			FROM ' . TITANIA_REVISIONS_PHPBB_TABLE . '
+			WHERE contrib_id = ' . (int) $this->contrib_id . '
+				AND revision_validated = 1
+			GROUP BY phpbb_version_branch';
+		$result = phpbb::$db->sql_query($sql);
+		$revisions = array();
+		while ($row = phpbb::$db->sql_fetchrow($result))
+		{
+			$revisions[(int) $row['phpbb_version_branch']] = (int) $row['revision_id'];
+		}
+		phpbb::$db->sql_freeresult($result);
+
+		if (empty($revisions))
+		{
+			return array();
+		}
+
+		$sql = 'SELECT revision_id
+			FROM ' . TITANIA_REVISIONS_TABLE . '
+			WHERE contrib_id = ' . (int) $this->contrib_id . '
+				AND ' . phpbb::$db->sql_in_set('revision_id', array_values($revisions)) . '
+				AND revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
+				AND revision_submitted = 1';
+		$result = phpbb::$db->sql_query($sql);
+		$revisions = array_flip($revisions); // revision_id => branch
+		$approved = array();
+		while ($row = phpbb::$db->sql_fetchrow($result))
+		{
+			$branch = (int) $revisions[(int) $row['revision_id']];
+			if (isset($allowed_branches[$branch]))
+			{
+				$approved[$branch] = $allowed_branches[$branch];
+			}
+		}
+		phpbb::$db->sql_freeresult($result);
+
+		return $approved;
+	}
 
 	/**
 	* Get all stored demo URLs.

--- a/includes/objects/contribution.php
+++ b/includes/objects/contribution.php
@@ -1041,15 +1041,57 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 	* @return array Branch names limited to the branches that have an approved
 	*	revision, keyed by branch - example: 31 => 'phpBB 3.1.x'
 	*/
-	public function get_approved_branches()
-	{
-		$this->get_download();
+public function get_approved_branches()
+{
+	$allowed_branches = $this->type->get_allowed_branches(true);
 
-		return array_intersect_key(
-			$this->type->get_allowed_branches(true),
-			$this->download
-		);
+	$this->get_download();
+	if (!empty($this->download))
+	{
+		return array_intersect_key($allowed_branches, $this->download);
 	}
+
+	// get_download() may intentionally return early (e.g. downloads disabled for non-team)
+	// so fall back to checking which branches have an approved, validated revision.
+	$sql = 'SELECT DISTINCT(phpbb_version_branch), MAX(revision_id) AS revision_id
+		FROM ' . TITANIA_REVISIONS_PHPBB_TABLE . '
+		WHERE contrib_id = ' . (int) $this->contrib_id . '
+			AND revision_validated = 1
+		GROUP BY phpbb_version_branch';
+	$result = phpbb::$db->sql_query($sql);
+	$revisions = array();
+	while ($row = phpbb::$db->sql_fetchrow($result))
+	{
+		$revisions[(int) $row['phpbb_version_branch']] = (int) $row['revision_id'];
+	}
+	phpbb::$db->sql_freeresult($result);
+
+	if (empty($revisions))
+	{
+		return array();
+	}
+
+	$sql = 'SELECT revision_id
+		FROM ' . TITANIA_REVISIONS_TABLE . '
+		WHERE contrib_id = ' . (int) $this->contrib_id . '
+			AND ' . phpbb::$db->sql_in_set('revision_id', array_values($revisions)) . '
+			AND revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
+			AND revision_submitted = 1';
+	$result = phpbb::$db->sql_query($sql);
+	$revisions = array_flip($revisions); // revision_id => branch
+	$approved = array();
+	while ($row = phpbb::$db->sql_fetchrow($result))
+	{
+		$branch = (int) $revisions[(int) $row['revision_id']];
+		if (isset($allowed_branches[$branch]))
+		{
+			$approved[$branch] = $allowed_branches[$branch];
+		}
+	}
+	phpbb::$db->sql_freeresult($result);
+
+	return $approved;
+}
 
 	/**
 	* Get all stored demo URLs.

--- a/styles/prosilver/template/contributions/contribution_manage.html
+++ b/styles/prosilver/template/contributions/contribution_manage.html
@@ -143,7 +143,7 @@
 						<textarea class="inputbox" name="nonactive_coauthors" id="nonactive_coauthors" rows="2" cols="20">{{ NONACTIVE_COAUTHORS }}</textarea>
 					</dd>
 				</dl>
-				{% if S_CAN_EDIT_DEMO %}
+				{% if S_CAN_EDIT_DEMO and loops.demo|length %}
 				<dl>
 					<dt><label for="demo_url">{{ lang('DEMO_URL') ~ lang('COLON') }}</label><br /><span>{{ lang('DEMO_URL_EXPLAIN') }}</span></dt>
 					<dd>


### PR DESCRIPTION
Fixes #377

The manage page built the demo URL box from every branch open for uploads, so a style approved only for 3.3 still offered the 3.2 field and install button. The demo box and the details page demo menu are now built from the branches that actually have an approved revision, the same source the download box uses. Stored URLs for branches that are not shown survive a save, so a pulled revision hides its demo without losing the URL if it is approved again.
