### PR TITLE
Guard against missing siblings on the styles demo page

### DIFF
--- a/contribution/style/demo/demo.php
+++ b/contribution/style/demo/demo.php
@@ -343,15 +343,15 @@ class demo
 			return false;
 		}
 
-		// Get siblings
+		// Get siblings; there is none at either end of the list
 		$prev = $this->sibling($this->default_style, 'prev');
 		$next = $this->sibling($this->default_style, 'next');
 
 		$this->template->assign_vars(array(
-			'U_PREV'	=> $prev['url'],
-			'PREV_ID'	=> $prev['id'],
-			'U_NEXT'	=> $next['url'],
-			'NEXT_ID'	=> $next['id'],
+			'U_PREV'	=> ($prev) ? $prev['url'] : false,
+			'PREV_ID'	=> ($prev) ? $prev['id'] : false,
+			'U_NEXT'	=> ($next) ? $next['url'] : false,
+			'NEXT_ID'	=> ($next) ? $next['id'] : false,
 		));
 
 		$category = '';


### PR DESCRIPTION
Fixes #447

sibling() returns false for the first and last style in the demo list, and assign_details() read the url and id from it anyway. The prev and next arrows now fall back to their disabled state.
