### PR TITLE
Show the subscribe checkbox in the correct state

### DIFF
--- a/styles/all/template/event/overall_footer_timezone_before.html
+++ b/styles/all/template/event/overall_footer_timezone_before.html
@@ -1,7 +1,7 @@
 {% if S_IN_TITANIA and U_SUBSCRIBE %}
 	<li data-last-responsive="true">
-		<a href="{{ U_SUBSCRIBE }}" title="{{ lang('SUBSCRIBE_TYPE') }}" data-ajax="toggle_link" data-toggle-class="icon {% if IS_SUBSCRIBED %}fa-check-square-o{% else %}fa-square-o{% endif %} fa-fw" data-toggle-text="{{ lang('SUBSCRIBE_TOGGLE') }}" data-toggle-url="{{ U_SUBSCRIBE_TOGGLE }}">
-			<i class="icon {% if IS_SUBSCRIBED %}fa-square-o{% else %}fa-check-square-o{% endif %} fa-fw" aria-hidden="true"></i><span>{{ lang('SUBSCRIBE_TYPE') }}</span>
+		<a href="{{ U_SUBSCRIBE }}" title="{{ lang('SUBSCRIBE_TYPE') }}" data-ajax="toggle_link" data-toggle-class="icon {% if IS_SUBSCRIBED %}fa-square-o{% else %}fa-check-square-o{% endif %} fa-fw" data-toggle-text="{{ lang('SUBSCRIBE_TOGGLE') }}" data-toggle-url="{{ U_SUBSCRIBE_TOGGLE }}">
+			<i class="icon {% if IS_SUBSCRIBED %}fa-check-square-o{% else %}fa-square-o{% endif %} fa-fw" aria-hidden="true"></i><span>{{ lang('SUBSCRIBE_TYPE') }}</span>
 		</a>
 	</li>
 {% endif %}


### PR DESCRIPTION
The footer subscribe link rendered a checked box when not subscribed and an empty one when subscribed because the two icon conditions were swapped. Checked now means subscribed, matching the watch links in core's prosilver.

Fixes #451
