### PR TITLE
Update each branch's release topic from its own latest revision

### DIFF
--- a/includes/objects/contribution.php
+++ b/includes/objects/contribution.php
@@ -1221,13 +1221,26 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 			$contrib_description = $this->contrib_desc;
 			message::decode($contrib_description, $this->contrib_desc_uid);
 
-			$download = reset($this->download); // Just need the first download entry
-			$phpbb_versions = $this->revisions[$download['revision_id']]['phpbb_versions'];
-			foreach ($phpbb_versions as $phpbb_version)
+			// Each branch has its own latest download and its own release topic.
+			foreach ($this->download as $branch => $download)
 			{
-				$branch = (int)$phpbb_version['phpbb_version_branch'];
-
 				if (empty($this->type->forum_database[$branch]))
+				{
+					continue;
+				}
+
+				// The revision row for this branch carries the tested phpBB version.
+				$phpbb_version = false;
+				foreach ($this->revisions[$download['revision_id']]['phpbb_versions'] as $version_row)
+				{
+					if ((int) $version_row['phpbb_version_branch'] == $branch)
+					{
+						$phpbb_version = $version_row;
+						break;
+					}
+				}
+
+				if ($phpbb_version === false)
 				{
 					continue;
 				}

--- a/includes/objects/contribution.php
+++ b/includes/objects/contribution.php
@@ -536,13 +536,22 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 					(($revision_id === false) ? ' AND r.revision_status = ' . ext::TITANIA_REVISION_APPROVED : '') . '
 					AND revision_submitted = 1';
 			$result = phpbb::$db->sql_query($sql);
-			$revisions = array_flip($revisions);
+			$rows = array();
 
 			while ($row = phpbb::$db->sql_fetchrow($result))
 			{
-				$this->download[$revisions[$row['revision_id']]] = $row;
+				$rows[(int) $row['revision_id']] = $row;
 			}
 			phpbb::$db->sql_freeresult($result);
+
+			// Branches sharing one latest revision each keep their own entry.
+			foreach ($revisions as $branch => $branch_revision_id)
+			{
+				if (isset($rows[$branch_revision_id]))
+				{
+					$this->download[$branch] = $rows[$branch_revision_id];
+				}
+			}
 			krsort($this->download);
 		}
 	}
@@ -898,8 +907,16 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 				titania::$config->colorizeit . '.html?sample=' . $this->clr_sample->get_id();
 		}
 
+		$displayed = array();
 		foreach ($this->download as $download)
 		{
+			// A revision latest for several branches gets one download block.
+			if (isset($displayed[$download['revision_id']]))
+			{
+				continue;
+			}
+			$displayed[$download['revision_id']] = true;
+
 			$vendor_version = $install_level = $install_time = $u_colorizeit = '';
 
 			if (!empty($this->revisions[$download['revision_id']]['phpbb_versions']))
@@ -1078,17 +1095,21 @@ class titania_contribution extends \phpbb\titania\entity\message_base
 				AND revision_status = ' . ext::TITANIA_REVISION_APPROVED . '
 				AND revision_submitted = 1';
 		$result = phpbb::$db->sql_query($sql);
-		$revisions = array_flip($revisions); // revision_id => branch
-		$approved = array();
+		$approved_revisions = array();
 		while ($row = phpbb::$db->sql_fetchrow($result))
 		{
-			$branch = (int) $revisions[(int) $row['revision_id']];
-			if (isset($allowed_branches[$branch]))
+			$approved_revisions[(int) $row['revision_id']] = true;
+		}
+		phpbb::$db->sql_freeresult($result);
+
+		$approved = array();
+		foreach ($revisions as $branch => $branch_revision_id)
+		{
+			if (isset($approved_revisions[$branch_revision_id]) && isset($allowed_branches[$branch]))
 			{
 				$approved[$branch] = $allowed_branches[$branch];
 			}
 		}
-		phpbb::$db->sql_freeresult($result);
 
 		return $approved;
 	}


### PR DESCRIPTION
The release topic update built one post body from the highest branch's latest download and applied it to every branch's topic.

For example, with a style supporting both 3.2 and 3.3:

1. The author releases 1.2.0 for 3.2 and 3.3. Both branches' release topics correctly show 1.2.0.
2. The author later releases 1.6.0 for 3.2 only. On approval, update_release_topic() takes the first download entry, which belongs to the highest branch: 3.3, still on 1.2.0. That revision lists both branches, so both first posts are rebuilt from it, and the 3.2 topic goes back to advertising 1.2.0 and its download link while the reply below it announces "Style Updated to version 1.6.0, See first post for Download Link".
3. Had the 3.3 branch's latest revision been 3.3-only instead, the loop would never visit 3.2 at all: the 3.2 first post would simply never update, and a branch whose revisions are never shared with the highest branch never gets a release topic created in the first place.

The first post is now rebuilt per branch from that branch's own latest approved revision, which also creates the release topic for a branch whose revision is not shared with the highest branch.

Fixes #373
